### PR TITLE
Native eth curve convex

### DIFF
--- a/contracts/ethereum/CurveConvex/CurveConvexStrategyETH.sol
+++ b/contracts/ethereum/CurveConvex/CurveConvexStrategyETH.sol
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.11;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import "./../../IAlluoStrategy.sol";
+import "./interfaces/ICvxBooster.sol";
+import "./interfaces/ICvxBaseRewardPool.sol";
+import "../../mock/IWrappedEther.sol";
+import "../../interfaces/IExchange.sol";
+
+contract CurveConvexStrategyETH is AccessControl, IAlluoStrategy {
+    using Address for address;
+    using SafeERC20 for IERC20;
+
+    ICvxBooster public constant cvxBooster =
+        ICvxBooster(0xF403C135812408BFbE8713b5A23a04b3D48AAE31);
+    IExchange public constant exchange =
+        IExchange(0x29c66CF57a03d41Cfe6d9ecB6883aa0E2AbA21Ec);
+    IERC20 public constant cvxRewards =
+        IERC20(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    IERC20 public constant crvRewards =
+        IERC20(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    uint8 public constant unwindDecimals = 2;
+    IWrappedEther public constant wETH =
+        IWrappedEther(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    receive() external payable {
+    }
+
+    constructor(
+        address voteExecutor,
+        address gnosis,
+        bool isTesting
+    ) {
+        if (isTesting) _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        else {
+            require(
+                voteExecutor.isContract(),
+                "CurveConvexStrategy: 1!contract"
+            );
+            require(gnosis.isContract(), "CurveConvexStrategy: 2!contract");
+            _grantRole(DEFAULT_ADMIN_ROLE, gnosis);
+            _grantRole(DEFAULT_ADMIN_ROLE, voteExecutor);
+        }
+    }
+
+    function invest(bytes calldata data, uint256 amount)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+        returns (bytes memory)
+    {
+        (
+            address curvePool,
+            IERC20 lpToken,
+            IERC20 poolToken,
+            uint8 poolSize,
+            uint8 tokenIndexInCurve,
+            uint256 poolId
+        ) = decodeEntryParams(data);
+        uint256 valueETH;
+        if (address(poolToken) == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE) {
+            wETH.withdraw(amount);
+            valueETH = amount;
+        } else {
+            poolToken.safeIncreaseAllowance(curvePool, amount);
+        }
+        // prepare amounts array for curve
+        uint256[4] memory fourPoolTokensAmount;
+        fourPoolTokensAmount[tokenIndexInCurve] = amount;
+
+        // encode call to curve - this ugly code handles different curve pool
+        // sizes and function selectors
+        bytes memory curveCall;
+        if (poolSize == 2) {
+            curveCall = abi.encodeWithSelector(
+                0x0b4c7e4d,
+                uint256[2]([fourPoolTokensAmount[0], fourPoolTokensAmount[1]]),
+                0
+            );
+        } else if (poolSize == 3) {
+            curveCall = abi.encodeWithSelector(
+                0x4515cef3,
+                uint256[3](
+                    [
+                        fourPoolTokensAmount[0],
+                        fourPoolTokensAmount[1],
+                        fourPoolTokensAmount[2]
+                    ]
+                ),
+                0
+            );
+        } else {
+            curveCall = abi.encodeWithSelector(
+                0x029b2f34,
+                fourPoolTokensAmount,
+                0
+            );
+        }
+
+        // execute call
+        curvePool.functionCallWithValue(curveCall, valueETH);
+
+        // skip investment in convex, if poolId is uint256 max value
+        if (poolId != type(uint256).max) {
+            // invest tokens to convex
+            uint256 lpAmount = lpToken.balanceOf(address(this));
+            lpToken.safeIncreaseAllowance(address(cvxBooster), lpAmount);
+            cvxBooster.deposit(poolId, lpAmount, true);
+        }
+
+        return
+            encodeExitParams(
+                curvePool,
+                address(poolToken),
+                address(lpToken),
+                tokenIndexInCurve,
+                poolId
+            );
+    }
+
+    function exitAll(
+        bytes calldata data,
+        uint256 unwindPercent,
+        address outputCoin,
+        address receiver,
+        bool swapRewards
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        (
+            address curvePool,
+            IERC20 poolToken,
+            IERC20 lpToken,
+            uint8 tokenIndexInCurve,
+            uint256 convexPoolId
+        ) = decodeExitParams(data);
+
+        uint256 lpAmount;
+        if (convexPoolId != type(uint256).max) {
+            ICvxBaseRewardPool rewards = getCvxRewardPool(convexPoolId);
+            lpAmount =
+                (rewards.balanceOf(address(this)) * unwindPercent) /
+                (10**(2 + unwindDecimals));
+
+            // withdraw Curve LPs and all rewards
+            rewards.withdrawAndUnwrap(lpAmount, true);
+        } else {
+            lpAmount = lpToken.balanceOf(address(this)) * unwindPercent / 10000;
+        }
+
+        if (lpAmount == 0) return;
+
+        // exit with coin that we used for entry
+        bytes memory curveCall = abi.encodeWithSignature(
+            "remove_liquidity_one_coin(uint256,int128,uint256)",
+            lpAmount,
+            tokenIndexInCurve,
+            0
+        );
+        uint256  valueETHBefore = address(this).balance;
+        curvePool.functionCall(curveCall);
+        uint256 ethDelta = address(this).balance - valueETHBefore;
+        if (ethDelta > 0) {
+            wETH.deposit{value: ethDelta}();
+            poolToken = IERC20(address(wETH));
+        } 
+        // execute exchanges and transfer all tokens to receiver
+        exchangeAll(poolToken, IERC20(outputCoin));
+        manageRewardsAndWithdraw(swapRewards, IERC20(outputCoin), receiver);
+    }
+
+    function exitOnlyRewards(
+        bytes calldata data,
+        address outputCoin,
+        address receiver,
+        bool swapRewards
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        (, , , , uint256 convexPoolId) = decodeExitParams(data);
+        ICvxBaseRewardPool rewards = getCvxRewardPool(convexPoolId);
+        rewards.getReward(address(this), true);
+
+        manageRewardsAndWithdraw(swapRewards, IERC20(outputCoin), receiver);
+    }
+
+    function multicall(
+        address[] calldata destinations,
+        bytes[] calldata calldatas
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        uint256 length = destinations.length;
+        require(length == calldatas.length, "CurveConvexStrategy: lengths");
+        for (uint256 i = 0; i < length; i++) {
+            destinations[i].functionCall(calldatas[i]);
+        }
+    }
+
+    function encodeEntryParams(
+        address curvePool,
+        address lpToken,
+        address poolToken,
+        uint8 poolSize,
+        uint8 tokenIndexInCurve,
+        uint256 convexPoolId
+    ) external pure returns (bytes memory) {
+        return
+            abi.encode(
+                curvePool,
+                lpToken,
+                poolToken,
+                poolSize,
+                tokenIndexInCurve,
+                convexPoolId
+            );
+    }
+
+    function encodeExitParams(
+        address curvePool,
+        address poolToken,
+        address lpToken,
+        uint8 tokenIndexInCurve,
+        uint256 convexPoolId
+    ) public pure returns (bytes memory) {
+        return
+            abi.encode(
+                curvePool,
+                poolToken,
+                lpToken,
+                tokenIndexInCurve,
+                convexPoolId
+            );
+    }
+
+    function decodeEntryParams(bytes calldata data)
+        public
+        pure
+        returns (
+            address,
+            IERC20,
+            IERC20,
+            uint8,
+            uint8,
+            uint256
+        )
+    {
+        require(data.length == 32 * 6, "CurveConvexStrategy: length en");
+        return
+            abi.decode(data, (address, IERC20, IERC20, uint8, uint8, uint256));
+    }
+
+    function decodeExitParams(bytes calldata data)
+        public
+        pure
+        returns (
+            address,
+            IERC20,
+            IERC20,
+            uint8,
+            uint256
+        )
+    {
+        require(data.length == 32 * 5, "CurveConvexStrategy: length ex");
+        return abi.decode(data, (address, IERC20, IERC20, uint8, uint256));
+    }
+
+    function exchangeAll(IERC20 fromCoin, IERC20 toCoin) private {
+        if (fromCoin == toCoin) return;
+        uint256 amount = IERC20(fromCoin).balanceOf(address(this));
+        if (amount == 0) return;
+
+        fromCoin.safeApprove(address(exchange), amount);
+        exchange.exchange(address(fromCoin), address(toCoin), amount, 0);
+    }
+
+    function manageRewardsAndWithdraw(
+        bool swapRewards,
+        IERC20 outputCoin,
+        address receiver
+    ) private {
+        if (swapRewards) {
+            exchangeAll(cvxRewards, outputCoin);
+            exchangeAll(crvRewards, outputCoin);
+        } else {
+            cvxRewards.safeTransfer(
+                receiver,
+                cvxRewards.balanceOf(address(this))
+            );
+            crvRewards.safeTransfer(
+                receiver,
+                crvRewards.balanceOf(address(this))
+            );
+        }
+
+        outputCoin.safeTransfer(receiver, outputCoin.balanceOf(address(this)));
+    }
+
+    function getCvxRewardPool(uint256 poolId)
+        private
+        view
+        returns (ICvxBaseRewardPool)
+    {
+        (, , , address pool, , ) = cvxBooster.poolInfo(poolId);
+        return ICvxBaseRewardPool(pool);
+    }
+}

--- a/contracts/ethereum/CurveConvex/CurveConvexStrategyLiquidity.sol
+++ b/contracts/ethereum/CurveConvex/CurveConvexStrategyLiquidity.sol
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.11;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import "./../../IAlluoStrategy.sol";
+import "./interfaces/ICvxBooster.sol";
+import "./interfaces/ICvxBaseRewardPool.sol";
+import "../../mock/IWrappedEther.sol";
+import "../../interfaces/IExchange.sol";
+
+contract CurveConvexStrategyTest is AccessControl, IAlluoStrategy {
+    using Address for address;
+    using SafeERC20 for IERC20;
+    // For polygon remember to change these constants
+
+
+    ICvxBooster public constant cvxBooster =
+        ICvxBooster(0xF403C135812408BFbE8713b5A23a04b3D48AAE31);
+    IExchange public constant exchange =
+        IExchange(0x29c66CF57a03d41Cfe6d9ecB6883aa0E2AbA21Ec);
+    IERC20 public constant cvxRewards =
+        IERC20(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    IERC20 public constant crvRewards =
+        IERC20(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    // IERC20 public constant crvRewards =
+    //     IERC20(0x1E4F97b9f9F913c46F1632781732927B9019C68b);
+
+    IWrappedEther public constant wETH =
+        IWrappedEther(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+        
+    constructor(
+        address voteExecutor,
+        address gnosis,
+        bool isTesting
+    ) {
+        if (isTesting) _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        else {
+            require(
+                voteExecutor.isContract(),
+                "CurveConvexStrategy: 1!contract"
+            );
+            require(gnosis.isContract(), "CurveConvexStrategy: 2!contract");
+            _grantRole(DEFAULT_ADMIN_ROLE, gnosis);
+            _grantRole(DEFAULT_ADMIN_ROLE, voteExecutor);
+        }
+    }
+
+    receive() external payable {
+    }
+
+    function invest(bytes calldata data, uint256 amount)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+        returns (bytes memory)
+    {
+        (
+            address curvePool,
+            IERC20 lpToken,
+            IERC20 poolToken,
+            uint8 poolSize,
+            uint8 tokenIndexInCurve,
+            uint256 poolId
+        ) = decodeEntryParams(data);
+        uint256 valueETH;
+        
+        if (address(poolToken) == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE) {
+            wETH.withdraw(amount);
+            valueETH = amount;
+        } else {
+            poolToken.safeIncreaseAllowance(curvePool, amount);
+        }
+        uint256[4] memory fourPoolTokensAmount;
+        fourPoolTokensAmount[tokenIndexInCurve] = amount;
+        bytes memory curveCall;
+      
+
+      if (poolSize == 2 ) {
+            curveCall = abi.encodeWithSelector(
+                0x0b4c7e4d,
+                uint256[2]([fourPoolTokensAmount[0], fourPoolTokensAmount[1]]),
+                0
+            );
+        }  else if (poolSize == 3) {
+            curveCall = abi.encodeWithSelector(
+                0x4515cef3,
+                uint256[3](
+                    [
+                        fourPoolTokensAmount[0],
+                        fourPoolTokensAmount[1],
+                        fourPoolTokensAmount[2]
+                    ]
+                ),
+                0
+            );
+        } else {
+            curveCall = abi.encodeWithSelector(
+                0x029b2f34,
+                fourPoolTokensAmount,
+                0
+            );
+        }
+
+        curvePool.functionCallWithValue(curveCall, valueETH);
+
+        // skip investment in convex, if poolId is uint256 max value
+        if (poolId != type(uint256).max) {
+            // invest tokens to convex
+            uint256 lpAmount = lpToken.balanceOf(address(this));
+            lpToken.safeIncreaseAllowance(address(cvxBooster), lpAmount);
+            cvxBooster.deposit(poolId, lpAmount, true);
+        }
+
+        return
+            encodeExitParams(
+                curvePool,
+                address(lpToken),
+                address(poolToken),
+                // Placeholder! Make sure to change.
+                "int128",
+                tokenIndexInCurve,
+                poolId
+            );
+    }
+
+    
+    function exitAll(
+        bytes calldata data,
+        uint256 unwindPercent,
+        address outputCoin,
+        address receiver,
+        bool swapRewards
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        (
+            address curvePool,
+            IERC20 lpToken,
+            IERC20 poolToken,
+            bytes memory typeOfTokenIndex,
+            uint8 tokenIndexInCurve,
+            uint256 convexPoolId
+        ) = decodeExitParams(data);
+        uint256 lpAmount;
+        if (convexPoolId != type(uint256).max) {
+            ICvxBaseRewardPool rewards = getCvxRewardPool(convexPoolId);
+            lpAmount =
+                (rewards.balanceOf(address(this)) * unwindPercent) / 10000;
+
+            // withdraw Curve LPs and all rewards
+            rewards.withdrawAndUnwrap(lpAmount, true);
+        } else {
+            lpAmount = lpToken.balanceOf(address(this)) * unwindPercent / 10000;
+        }
+
+        if (lpAmount == 0) return;
+        // exit with coin that we used for entry
+        bytes memory curveCall = abi.encodeWithSignature(
+            string(bytes.concat("remove_liquidity_one_coin(uint256,", typeOfTokenIndex,",uint256)")),
+            lpAmount,
+            tokenIndexInCurve,
+            0
+        );
+        uint256  valueETHBefore = address(this).balance;
+        curvePool.functionCall(curveCall);
+        uint256 ethDelta = address(this).balance - valueETHBefore;
+        if (ethDelta > 0) {
+            wETH.deposit{value: ethDelta}();
+            poolToken = IERC20(address(wETH));
+        } 
+        // execute exchanges and transfer all tokens to receiver
+        exchangeAll(poolToken, IERC20(outputCoin));
+        manageRewardsAndWithdraw(swapRewards, IERC20(outputCoin), receiver);
+    }
+
+    function exitOnlyRewards(
+        bytes calldata data,
+        address outputCoin,
+        address receiver,
+        bool swapRewards
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        (, , , , , uint256 convexPoolId) = decodeExitParams(data);
+        ICvxBaseRewardPool rewards = getCvxRewardPool(convexPoolId);
+        rewards.getReward(address(this), true);
+
+        manageRewardsAndWithdraw(swapRewards, IERC20(outputCoin), receiver);
+    }
+
+    function multicall(
+        address[] calldata destinations,
+        bytes[] calldata calldatas
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        uint256 length = destinations.length;
+        require(length == calldatas.length, "CurveConvexStrategy: lengths");
+        for (uint256 i = 0; i < length; i++) {
+            destinations[i].functionCall(calldatas[i]);
+        }
+    }
+
+    function encodeEntryParams(
+        address curvePool,
+        address lpToken,
+        address poolToken,
+        uint8 poolSize,
+        uint8 tokenIndexInCurve,
+        uint256 convexPoolId
+    ) external pure returns (bytes memory) {
+        return
+            abi.encode(
+                curvePool,
+                lpToken,
+                poolToken,
+                poolSize,
+                tokenIndexInCurve,
+                convexPoolId
+            );
+    }
+
+    function encodeExitParams(
+        address curvePool,
+        address lpToken,
+        address poolToken,
+        bytes memory typeOfTokenIndex,
+        uint8 tokenIndexInCurve,
+        uint256 convexPoolId
+    ) public pure returns (bytes memory) {
+        return
+            abi.encode(
+                curvePool,
+                lpToken,
+                poolToken,
+                typeOfTokenIndex,
+                tokenIndexInCurve,
+                convexPoolId
+            );
+    }
+
+    function decodeEntryParams(bytes calldata data)
+        public
+        pure
+        returns (
+            address,
+            IERC20,
+            IERC20,
+            uint8,
+            uint8,
+            uint256
+        )
+    {
+        require(data.length == 32 * 6, "CurveConvexStrategy: length en");
+        return
+            abi.decode(data, (address, IERC20, IERC20, uint8, uint8, uint256));
+    }
+
+    function decodeExitParams(bytes calldata data)
+        public
+        pure
+        returns (
+            address,
+            IERC20,
+            IERC20,
+            bytes memory,
+            uint8,
+            uint256
+        )
+    {
+        require(data.length == 32 * 8, "CurveConvexStrategy: length ex");
+        return abi.decode(data, (address, IERC20, IERC20, bytes, uint8, uint256));
+    }
+
+    function exchangeAll(IERC20 fromCoin, IERC20 toCoin) private {
+        if (fromCoin == toCoin) return;
+        uint256 amount = IERC20(fromCoin).balanceOf(address(this));
+        if (amount == 0) return;
+
+        fromCoin.safeApprove(address(exchange), amount);
+        exchange.exchange(address(fromCoin), address(toCoin), amount, 0);
+    }
+
+    function manageRewardsAndWithdraw(
+        bool swapRewards,
+        IERC20 outputCoin,
+        address receiver
+    ) private {
+        if (swapRewards) {
+            exchangeAll(cvxRewards, outputCoin);
+            exchangeAll(crvRewards, outputCoin);
+        } else {
+            cvxRewards.safeTransfer(
+                receiver,
+                cvxRewards.balanceOf(address(this))
+            );
+            crvRewards.safeTransfer(
+                receiver,
+                crvRewards.balanceOf(address(this))
+            );
+        }
+
+        outputCoin.safeTransfer(receiver, outputCoin.balanceOf(address(this)));
+    }
+
+    function getCvxRewardPool(uint256 poolId)
+        private
+        view
+        returns (ICvxBaseRewardPool)
+    {
+        (, , , address pool, , ) = cvxBooster.poolInfo(poolId);
+        return ICvxBaseRewardPool(pool);
+    }
+}

--- a/contracts/ethereum/CurveConvex/CurveFraxConvexStrategy.sol
+++ b/contracts/ethereum/CurveConvex/CurveFraxConvexStrategy.sol
@@ -14,8 +14,6 @@ import "../../interfaces/IExchange.sol";
 import "./interfaces/IFraxFarmERC20.sol";
 import "./interfaces/IConvexWrapper.sol";
 
-import "hardhat/console.sol";
-    
 contract CurveFraxConvexStrategy is AccessControl, IAlluoStrategy {
     using Address for address;
     using SafeERC20 for IERC20;
@@ -109,11 +107,6 @@ contract CurveFraxConvexStrategy is AccessControl, IAlluoStrategy {
         // skip investment in convex, if poolId is uint256 max value
         if (poolId != type(uint256).max) {
             // invest tokens to convex
-            {(address rewardToken,,,uint128 reward_remaining) = IConvexWrapper(address(stakeToken)).rewards(0);
-            (address rewardToken2,,,uint128 reward_remaining2) = IConvexWrapper(address(stakeToken)).rewards(1);
-                 console.log(rewardToken, reward_remaining);
-                        console.log(rewardToken2, reward_remaining2);
-            }
             uint256 crvLpAmount = crvLpToken.balanceOf(address(this));
             crvLpToken.safeIncreaseAllowance(address(stakeToken), crvLpAmount);
             // Deposit these crvLptokens into the convex wrapper to get staked fraxLP tokens

--- a/contracts/ethereum/CurveConvex/CurveFraxConvexStrategy.sol
+++ b/contracts/ethereum/CurveConvex/CurveFraxConvexStrategy.sol
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.11;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import "./../../IAlluoStrategy.sol";
+import "./interfaces/ICvxBooster.sol";
+import "./interfaces/ICvxBaseRewardPool.sol";
+import "../../mock/IWrappedEther.sol";
+import "../../interfaces/IExchange.sol";
+import "./interfaces/IFraxFarmERC20.sol";
+import "./interfaces/IConvexWrapper.sol";
+
+import "hardhat/console.sol";
+    
+contract CurveFraxConvexStrategy is AccessControl, IAlluoStrategy {
+    using Address for address;
+    using SafeERC20 for IERC20;
+    event Locked(bytes32 data);
+
+    ICvxBooster public constant cvxBooster =
+        ICvxBooster(0xF403C135812408BFbE8713b5A23a04b3D48AAE31);
+    IExchange public constant exchange =
+        IExchange(0x29c66CF57a03d41Cfe6d9ecB6883aa0E2AbA21Ec);
+    IERC20 public constant cvxRewards =
+        IERC20(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    IERC20 public constant crvRewards =
+        IERC20(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    IERC20 public constant fraxRewards = 
+        IERC20(0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0);
+    uint8 public constant unwindDecimals = 2;
+
+    receive() external payable {
+    }
+
+    constructor(
+        address voteExecutor,
+        address gnosis,
+        bool isTesting
+    ) {
+        if (isTesting) _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        else {
+            require(
+                voteExecutor.isContract(),
+                "CurveConvexStrategy: 1!contract"
+            );
+            require(gnosis.isContract(), "CurveConvexStrategy: 2!contract");
+            _grantRole(DEFAULT_ADMIN_ROLE, gnosis);
+            _grantRole(DEFAULT_ADMIN_ROLE, voteExecutor);
+        }
+    }
+
+    function invest(bytes calldata data, uint256 amount)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+        returns (bytes memory)
+    {
+        (
+            address curvePool,
+            IERC20 crvLpToken,
+            IERC20 poolToken,
+            uint8 poolSize,
+            uint8 tokenIndexInCurve,
+            uint256 poolId,
+            IERC20 stakeToken, 
+            address fraxPool,
+            uint256 duration
+        ) = decodeEntryParams(data);
+        poolToken.safeIncreaseAllowance(curvePool, amount);
+        // prepare amounts array for curve
+        uint256[4] memory fourPoolTokensAmount;
+        fourPoolTokensAmount[tokenIndexInCurve] = amount;
+
+        // encode call to curve - this ugly code handles different curve pool
+        // sizes and function selectors
+        bytes memory curveCall;
+        if (poolSize == 2) {
+            curveCall = abi.encodeWithSelector(
+                0x0b4c7e4d,
+                uint256[2]([fourPoolTokensAmount[0], fourPoolTokensAmount[1]]),
+                0
+            );
+        } else if (poolSize == 3) {
+            curveCall = abi.encodeWithSelector(
+                0x4515cef3,
+                uint256[3](
+                    [
+                        fourPoolTokensAmount[0],
+                        fourPoolTokensAmount[1],
+                        fourPoolTokensAmount[2]
+                    ]
+                ),
+                0
+            );
+        } else {
+            curveCall = abi.encodeWithSelector(
+                0x029b2f34,
+                fourPoolTokensAmount,
+                0
+            );
+        }
+
+        // execute call
+        curvePool.functionCall(curveCall);
+        bytes32 kek_id;
+        // skip investment in convex, if poolId is uint256 max value
+        if (poolId != type(uint256).max) {
+            // invest tokens to convex
+            {(address rewardToken,,,uint128 reward_remaining) = IConvexWrapper(address(stakeToken)).rewards(0);
+            (address rewardToken2,,,uint128 reward_remaining2) = IConvexWrapper(address(stakeToken)).rewards(1);
+                 console.log(rewardToken, reward_remaining);
+                        console.log(rewardToken2, reward_remaining2);
+            }
+            uint256 crvLpAmount = crvLpToken.balanceOf(address(this));
+            crvLpToken.safeIncreaseAllowance(address(stakeToken), crvLpAmount);
+            // Deposit these crvLptokens into the convex wrapper to get staked fraxLP tokens
+            IConvexWrapper(address(stakeToken)).deposit(crvLpAmount, address(this));
+            uint256 fraxLpAmount = stakeToken.balanceOf(address(this));
+            stakeToken.safeIncreaseAllowance(fraxPool, fraxLpAmount);
+            // Now stake and lock these LP tokens into the frax farm.
+            kek_id = IFraxFarmERC20(fraxPool).stakeLocked(fraxLpAmount, duration);
+        }
+        emit Locked(kek_id);
+
+        return
+            encodeExitParams(
+                curvePool,
+                address(poolToken),
+                address(crvLpToken),
+                tokenIndexInCurve,
+                poolId,
+                address(fraxPool),
+                kek_id
+            );
+    }
+
+    function exitAll(
+        bytes calldata data,
+        uint256 unwindPercent,
+        address outputCoin,
+        address receiver,
+        bool swapRewards
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        (
+            address curvePool,
+            IERC20 poolToken,
+            IERC20 crvLpToken,
+            uint8 tokenIndexInCurve,
+            uint256 convexPoolId,
+            address fraxPool,
+            bytes32 kek_id
+        ) = decodeExitParams(data);
+        uint256 lpAmount;
+        if (convexPoolId != type(uint256).max) {
+            // Withdraw locked fraxLP tokens.
+            // Get all rewards accumulated.
+
+            address[] memory fraxPoolRewards = IFraxFarmERC20(fraxPool).getAllRewardTokens();
+            IFraxFarmERC20(fraxPool).withdrawLocked(kek_id, address(this));
+            // Get rewards from Frax
+            IFraxFarmERC20(fraxPool).getReward(address(this));
+            // Get rewards from Convex
+            IConvexWrapper(IFraxFarmERC20(fraxPool).stakingToken()).getReward(address(this));
+
+            // Simply send all frax rewards to receiver.
+            for (uint256 i; i < fraxPoolRewards.length; i++) {
+                IERC20(fraxPoolRewards[i]).transfer(receiver, IERC20(fraxPoolRewards[i]).balanceOf(address(this)));
+            }
+            // Withdraw all the curveLPs and curve rewards.
+            lpAmount =
+                ( IERC20(IFraxFarmERC20(fraxPool).stakingToken()).balanceOf(address(this)) * unwindPercent) /
+                (10**(2 + unwindDecimals));
+
+            IConvexWrapper(IFraxFarmERC20(fraxPool).stakingToken()).withdrawAndUnwrap(lpAmount);
+        } else {
+            lpAmount = crvLpToken.balanceOf(address(this)) * unwindPercent / 10000;
+        }
+
+        if (lpAmount == 0) return;
+
+        // exit with coin that we used for entry
+        bytes memory curveCall = abi.encodeWithSignature(
+            "remove_liquidity_one_coin(uint256,int128,uint256)",
+            lpAmount,
+            tokenIndexInCurve,
+            0
+        );
+        curvePool.functionCall(curveCall);
+        // execute exchanges and transfer all tokens to receiver
+        exchangeAll(poolToken, IERC20(outputCoin));
+        manageRewardsAndWithdraw(swapRewards, IERC20(outputCoin), receiver);
+    }
+
+    function exitOnlyRewards(
+        bytes calldata data,
+        address outputCoin,
+        address receiver,
+        bool swapRewards
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+
+        (
+            ,
+            ,
+            ,
+            ,
+            uint256 convexPoolId,
+            address fraxPool,
+        ) = decodeExitParams(data);
+        if (convexPoolId != type(uint256).max) {
+            // Withdraw locked fraxLP tokens.
+            // Get all rewards accumulated.
+            address[] memory fraxPoolRewards = IFraxFarmERC20(fraxPool).getAllRewardTokens();
+            // Get rewards from Frax
+            IFraxFarmERC20(fraxPool).getReward(address(this));
+            // Get rewards from Convex
+            IConvexWrapper(IFraxFarmERC20(fraxPool).stakingToken()).getReward(address(this), address(this));
+            // Simply send all rewards to receiver.
+            for (uint256 i; i < fraxPoolRewards.length; i++) {
+                IERC20(fraxPoolRewards[i]).transfer(receiver, IERC20(fraxPoolRewards[i]).balanceOf(address(this)));
+            }
+        } else {
+            ICvxBaseRewardPool rewards = getCvxRewardPool(convexPoolId);
+            rewards.getReward(address(this), true);
+        }
+        manageRewardsAndWithdraw(swapRewards, IERC20(outputCoin), receiver);
+    }
+    function multicall(
+        address[] calldata destinations,
+        bytes[] calldata calldatas
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        uint256 length = destinations.length;
+        require(length == calldatas.length, "CurveConvexStrategy: lengths");
+        for (uint256 i = 0; i < length; i++) {
+            destinations[i].functionCall(calldatas[i]);
+        }
+    }
+
+    function encodeEntryParams(
+        address curvePool,
+        address crvLpToken,
+        address poolToken,
+        uint8 poolSize,
+        uint8 tokenIndexInCurve,
+        uint256 convexPoolId,
+        address stakeToken,
+        address fraxPool,
+        uint256 duration
+    ) external pure returns (bytes memory) {
+        return
+            abi.encode(
+                curvePool,
+                crvLpToken,
+                poolToken,
+                poolSize,
+                tokenIndexInCurve,
+                convexPoolId,
+                stakeToken, 
+                fraxPool,
+                duration
+            );
+    }
+
+    function encodeExitParams(
+        address curvePool,
+        address poolToken,
+        address crvLpToken,
+        uint8 tokenIndexInCurve,
+        uint256 convexPoolId,
+        address fraxPool,
+        bytes32 kek
+    ) public pure returns (bytes memory) {
+        return
+            abi.encode(
+                curvePool,
+                poolToken,
+                crvLpToken,
+                tokenIndexInCurve,
+                convexPoolId,
+                fraxPool,
+                kek
+            );
+    }
+
+    function decodeEntryParams(bytes calldata data)
+        public
+        pure
+        returns (
+            address,
+            IERC20,
+            IERC20,
+            uint8,
+            uint8,
+            uint256,
+            IERC20,
+            address,
+            uint256
+        )
+    {
+        require(data.length == 32 * 9, "CurveConvexStrategy: length en");
+        return
+            abi.decode(data, (address, IERC20, IERC20, uint8, uint8, uint256, IERC20, address, uint256));
+    }
+
+    function decodeExitParams(bytes calldata data)
+        public
+        pure
+        returns (
+            address,
+            IERC20,
+            IERC20,
+            uint8,
+            uint256,
+            address,
+            bytes32
+        )
+    {
+        require(data.length == 32 * 7, "CurveConvexStrategy: length ex");
+        return abi.decode(data, (address, IERC20, IERC20, uint8, uint256, address,bytes32));
+    }
+
+    function exchangeAll(IERC20 fromCoin, IERC20 toCoin) private {
+        if (fromCoin == toCoin) return;
+        uint256 amount = IERC20(fromCoin).balanceOf(address(this));
+        if (amount == 0) return;
+
+        fromCoin.safeApprove(address(exchange), amount);
+        exchange.exchange(address(fromCoin), address(toCoin), amount, 0);
+    }
+
+    function manageRewardsAndWithdraw(
+        bool swapRewards,
+        IERC20 outputCoin,
+        address receiver
+    ) private {
+        if (swapRewards) {
+            exchangeAll(cvxRewards, outputCoin);
+            exchangeAll(crvRewards, outputCoin);
+        } else {
+            cvxRewards.safeTransfer(
+                receiver,
+                cvxRewards.balanceOf(address(this))
+            );
+
+            crvRewards.safeTransfer(
+                receiver,
+                crvRewards.balanceOf(address(this))
+            );
+        }
+
+        outputCoin.safeTransfer(receiver, outputCoin.balanceOf(address(this)));
+    }
+
+    function getCvxRewardPool(uint256 poolId)
+        private
+        view
+        returns (ICvxBaseRewardPool)
+    {
+        (, , , address pool, , ) = cvxBooster.poolInfo(poolId);
+        return ICvxBaseRewardPool(pool);
+    }
+}

--- a/contracts/ethereum/CurveConvex/interfaces/IConvexWrapper.sol
+++ b/contracts/ethereum/CurveConvex/interfaces/IConvexWrapper.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.11;
+
+
+interface IConvexWrapper{
+
+   struct EarnedData {
+        address token;
+        uint256 amount;
+    }
+
+  function convexPoolId() external view returns(uint256 _poolId);
+  function balanceOf(address _account) external view returns(uint256);
+  function totalBalanceOf(address _account) external view returns(uint256);
+  function deposit(uint256 _amount, address _to) external;
+  function stake(uint256 _amount, address _to) external;
+  function withdraw(uint256 _amount) external;
+  function withdrawAndUnwrap(uint256 _amount) external;
+  function getReward(address _account) external;
+  function getReward(address _account, address _forwardTo) external;
+  function rewardLength() external view returns(uint256);
+  function earned(address _account) external view returns(EarnedData[] memory claimable);
+  function setVault(address _vault) external;
+  function user_checkpoint(address[2] calldata _accounts) external returns(bool);
+  function createVault(uint256 _pid) external returns (address);
+   function stakeLockedCurveLp(uint256 _liquidity, uint256 _secs) external returns (bytes32 kek_id);
+   function withdrawLockedAndUnwrap(bytes32 _kek_id) external;
+   function getReward() external;
+   function owner() external view returns (address);
+   function rewards(uint256) external view returns (address, address, uint128, uint128);
+}

--- a/contracts/ethereum/CurveConvex/interfaces/IFraxFarmERC20.sol
+++ b/contracts/ethereum/CurveConvex/interfaces/IFraxFarmERC20.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+interface IFraxFarmERC20 {
+    
+    struct LockedStake {
+        bytes32 kek_id;
+        uint256 start_timestamp;
+        uint256 liquidity;
+        uint256 ending_timestamp;
+        uint256 lock_multiplier; // 6 decimals of precision. 1x = 1000000
+    }
+
+   struct EarnedData {
+        address token;
+        uint256 amount;
+    }
+    function earned() external view returns(EarnedData[] memory claimable);
+    function rewardLength() external view returns(uint256);
+
+    function owner() external view returns (address);
+    function stakingToken() external view returns (address);
+    function fraxPerLPToken() external view returns (uint256);
+    function calcCurCombinedWeight(address account) external view
+        returns (
+            uint256 old_combined_weight,
+            uint256 new_vefxs_multiplier,
+            uint256 new_combined_weight
+        );
+    function lockedStakesOf(address account) external view returns (LockedStake[] memory);
+    function lockedStakesOfLength(address account) external view returns (uint256);
+    function lockAdditional(bytes32 kek_id, uint256 addl_liq) external;
+    function lockLonger(bytes32 kek_id, uint256 new_ending_ts) external;
+    function stakeLocked(uint256 liquidity, uint256 secs) external returns (bytes32);
+    function withdrawLocked(bytes32 kek_id, address destination_address) external returns (uint256);
+    function withdrawLocked(bytes32 kek_id) external returns (uint256);
+
+
+
+    function periodFinish() external view returns (uint256);
+    function getAllRewardTokens() external view returns (address[] memory);
+    // function earned(address account) external view returns (uint256[] memory new_earned);
+    function totalLiquidityLocked() external view returns (uint256);
+    function lockedLiquidityOf(address account) external view returns (uint256);
+    function totalCombinedWeight() external view returns (uint256);
+    function combinedWeightOf(address account) external view returns (uint256);
+    function lockMultiplier(uint256 secs) external view returns (uint256);
+    function rewardRates(uint256 token_idx) external view returns (uint256 rwd_rate);
+
+    function userStakedFrax(address account) external view returns (uint256);
+    function proxyStakedFrax(address proxy_address) external view returns (uint256);
+    function maxLPForMaxBoost(address account) external view returns (uint256);
+    function minVeFXSForMaxBoost(address account) external view returns (uint256);
+    function minVeFXSForMaxBoostProxy(address proxy_address) external view returns (uint256);
+    function veFXSMultiplier(address account) external view returns (uint256 vefxs_multiplier);
+
+    function toggleValidVeFXSProxy(address proxy_address) external;
+    function proxyToggleStaker(address staker_address) external;
+    function stakerSetVeFXSProxy(address proxy_address) external;
+    function getReward(address destination_address) external returns (uint256[] memory);
+    function getReward(bool claim) external returns (uint256[] memory);
+
+    function vefxs_max_multiplier() external view returns(uint256);
+    function vefxs_boost_scale_factor() external view returns(uint256);
+    function vefxs_per_frax_for_max_boost() external view returns(uint256);
+    function getProxyFor(address addr) external view returns (address);
+
+    function sync() external;
+}

--- a/scripts/deployCurveFraxConvexStrategy.ts
+++ b/scripts/deployCurveFraxConvexStrategy.ts
@@ -1,0 +1,17 @@
+import { ethers } from "hardhat";
+
+async function main() {
+   let voteExecutor = 
+    console.log("Deploying...")
+    const CurveFraxConvexStrategy = await ethers.getContractFactory("CurveFraxConvexStrategy");
+    const strategy = await CurveFraxConvexStrategy.deploy(ethers.constants.AddressZero,ethers.constants.AddressZero, true);
+
+    console.log("Deployed at", strategy.address);
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/test/CurveConvexStrategy.ts
+++ b/test/CurveConvexStrategy.ts
@@ -2,14 +2,13 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
 import { AbiCoder, defaultAbiCoder, parseEther, parseUnits } from "ethers/lib/utils";
 import { ethers } from "hardhat";
-import { CurveConvexStrategy, ICvxBooster, IERC20Metadata, IExchange } from "../typechain";
-
+import { CurveConvexStrategy, CurveConvexStrategyETH, ICvxBooster, IERC20Metadata, IExchange, IWrappedEther } from "../typechain";
 
 describe("CurveConvexStrategy", function () {
-    let strategy: CurveConvexStrategy;
+    let strategy: CurveConvexStrategyETH;
     let signers: SignerWithAddress[];
 
-    let usdc: IERC20Metadata, usdt: IERC20Metadata, frax: IERC20Metadata, crv: IERC20Metadata, cvx: IERC20Metadata;
+    let usdc: IERC20Metadata, usdt: IERC20Metadata, frax: IERC20Metadata, crv: IERC20Metadata, cvx: IERC20Metadata, weth: IERC20Metadata;
     let cvxBooster: ICvxBooster;
     let exchange: IExchange;
 
@@ -27,7 +26,7 @@ describe("CurveConvexStrategy", function () {
         frax = await ethers.getContractAt('IERC20Metadata', '0x853d955acef822db058eb8505911ed77f175b99e');
         crv = await ethers.getContractAt("IERC20Metadata", "0xD533a949740bb3306d119CC777fa900bA034cd52");
         cvx = await ethers.getContractAt("IERC20Metadata", "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B");
-
+        weth = await ethers.getContractAt("IERC20Metadata", "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
         cvxBooster = await ethers.getContractAt("ICvxBooster", "0xF403C135812408BFbE8713b5A23a04b3D48AAE31");
         exchange = await ethers.getContractAt("IExchange", "0x29c66CF57a03d41Cfe6d9ecB6883aa0E2AbA21Ec")
 
@@ -36,321 +35,538 @@ describe("CurveConvexStrategy", function () {
         await exchange.exchange(
             ZERO_ADDR, frax.address, value, 0, { value: value }
         )
+
     });
 
     beforeEach(async () => {
-        const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
+        const Strategy = await ethers.getContractFactory("CurveConvexStrategyETH");
         strategy = await Strategy.deploy(ZERO_ADDR, ZERO_ADDR, true);
+        let wrappedEther = await ethers.getContractAt("IWrappedEther", "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2") as IWrappedEther
+        await wrappedEther.deposit({value: ethers.utils.parseEther("100")})
     });
 
-    it("Should check initial contract state", async () => {
-        const cvxBooster = "0xF403C135812408BFbE8713b5A23a04b3D48AAE31";
-        const exchange = "0x29c66CF57a03d41Cfe6d9ecB6883aa0E2AbA21Ec";
-        const cvxRewards = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
-        const crvRewards = "0xD533a949740bb3306d119CC777fa900bA034cd52";
-        const unwindDecimals = 2;
-        const adminRole = await strategy.DEFAULT_ADMIN_ROLE();
+    // it("Should check initial contract state", async () => {
+    //     const cvxBooster = "0xF403C135812408BFbE8713b5A23a04b3D48AAE31";
+    //     const exchange = "0x29c66CF57a03d41Cfe6d9ecB6883aa0E2AbA21Ec";
+    //     const cvxRewards = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+    //     const crvRewards = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+    //     const unwindDecimals = 2;
+    //     const adminRole = await strategy.DEFAULT_ADMIN_ROLE();
 
-        expect(await strategy.cvxBooster()).to.be.equal(cvxBooster);
-        expect(await strategy.exchange()).to.be.equal(exchange);
-        expect(await strategy.cvxRewards()).to.be.equal(cvxRewards);
-        expect(await strategy.crvRewards()).to.be.equal(crvRewards);
-        expect(await strategy.unwindDecimals()).to.be.equal(unwindDecimals);
+    //     expect(await strategy.cvxBooster()).to.be.equal(cvxBooster);
+    //     expect(await strategy.exchange()).to.be.equal(exchange);
+    //     expect(await strategy.cvxRewards()).to.be.equal(cvxRewards);
+    //     expect(await strategy.crvRewards()).to.be.equal(crvRewards);
+    //     expect(await strategy.unwindDecimals()).to.be.equal(unwindDecimals);
 
-        expect(await strategy.hasRole(adminRole, signers[0].address)).to.be.true;
-    });
+    //     expect(await strategy.hasRole(adminRole, signers[0].address)).to.be.true;
+    // });
 
-    it("Should check initial contract state (testing == false)", async () => {
-        const contract1 = usdc.address;
-        const contract2 = usdt.address;
-        const adminRole = ethers.constants.HashZero;
+    // it("Should check initial contract state (testing == false)", async () => {
+    //     const contract1 = usdc.address;
+    //     const contract2 = usdt.address;
+    //     const adminRole = ethers.constants.HashZero;
 
-        expect(contract1).to.not.be.equal(contract2);
+    //     expect(contract1).to.not.be.equal(contract2);
 
-        const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
-        const newStrategy = await Strategy.deploy(contract1, contract2, false);
+    //     const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
+    //     const newStrategy = await Strategy.deploy(contract1, contract2, false);
 
-        expect(await newStrategy.hasRole(adminRole, contract1)).to.be.true;
-        expect(await newStrategy.hasRole(adminRole, contract2)).to.be.true;
-    });
+    //     expect(await newStrategy.hasRole(adminRole, contract1)).to.be.true;
+    //     expect(await newStrategy.hasRole(adminRole, contract2)).to.be.true;
+    // });
 
-    it("Should not deploy contract (gnosis/voteExecutor not contract)", async () => {
-        const notContract = signers[1].address;
-        const contract = usdc.address;
+    // it("Should not deploy contract (gnosis/voteExecutor not contract)", async () => {
+    //     const notContract = signers[1].address;
+    //     const contract = usdc.address;
 
-        const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
+    //     const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
 
-        let newStrategy = Strategy.deploy(notContract, contract, false);
-        await expect(newStrategy).to.be.revertedWith("CurveConvexStrategy: 1!contract");
+    //     let newStrategy = Strategy.deploy(notContract, contract, false);
+    //     await expect(newStrategy).to.be.revertedWith("CurveConvexStrategy: 1!contract");
 
-        newStrategy = Strategy.deploy(contract, notContract, false);
-        await expect(newStrategy).to.be.revertedWith("CurveConvexStrategy: 2!contract");
+    //     newStrategy = Strategy.deploy(contract, notContract, false);
+    //     await expect(newStrategy).to.be.revertedWith("CurveConvexStrategy: 2!contract");
+    // })
+
+    // it("Should check roles", async () => {
+    //     const contract = usdc.address;
+    //     const roleError = `AccessControl: account ${signers[0].address.toLowerCase()} is missing role ${ethers.constants.HashZero}`;
+
+    //     const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
+    //     const newStrategy = await Strategy.deploy(contract, contract, false);
+
+    //     await expect(newStrategy.invest("0x", 0)).to.be.revertedWith(roleError);
+    //     await expect(newStrategy.exitAll("0x", 0, contract, contract, true)).to.be.revertedWith(roleError);
+    //     await expect(newStrategy.exitOnlyRewards("0x", contract, contract, true)).to.be.revertedWith(roleError);
+    //     await expect(newStrategy.multicall([], [])).to.be.revertedWith(roleError);
+    // });
+
+    // it("Should check correct encoders/decoders", async () => {
+    //     const curvePool = "0x0000000000000000000000000000000000000001";
+    //     const poolToken = "0x0000000000000000000000000000000000000002";
+    //     const poolSize = 3;
+    //     const tokenIndexInCurve = 4;
+    //     const convexPoolId = 5;
+    //     const lpToken = "0x0000000000000000000000000000000000000006"
+
+    //     const entry = defaultAbiCoder.encode(
+    //         ["address", "address ", "address", "uint8", "uint8", "uint256"],
+    //         [curvePool, lpToken, poolToken, poolSize, tokenIndexInCurve, convexPoolId]
+    //     )
+    //     const exit = defaultAbiCoder.encode(
+    //         ["address", "address", "address", "uint8", "uint256"],
+    //         [curvePool, poolToken, lpToken, tokenIndexInCurve, convexPoolId]
+    //     );
+
+    //     expect(await strategy.encodeEntryParams(
+    //         curvePool, lpToken, poolToken, poolSize, tokenIndexInCurve, convexPoolId
+    //     )).to.be.equal(entry);
+
+    //     expect(await strategy.encodeExitParams(
+    //         curvePool, poolToken, lpToken, tokenIndexInCurve, convexPoolId
+    //     )).to.be.equal(exit);
+
+    //     const entryStruct = await strategy.decodeEntryParams(entry);
+    //     const exitStruct = await strategy.decodeExitParams(exit);
+
+    //     expect(entryStruct[0]).to.be.equal(curvePool);
+    //     expect(entryStruct[1]).to.be.equal(lpToken);
+    //     expect(entryStruct[2]).to.be.equal(poolToken);
+    //     expect(entryStruct[3]).to.be.equal(poolSize);
+    //     expect(entryStruct[4]).to.be.equal(tokenIndexInCurve);
+    //     expect(entryStruct[5]).to.be.equal(convexPoolId);
+
+    //     expect(exitStruct[0]).to.be.equal(curvePool);
+    //     expect(exitStruct[1]).to.be.equal(poolToken);
+    //     expect(exitStruct[2]).to.be.equal(lpToken);
+    //     expect(exitStruct[3]).to.be.equal(tokenIndexInCurve);
+    //     expect(exitStruct[4]).to.be.equal(convexPoolId);
+    // });
+
+    // it("Should revert decoders if data length is wrong", async () => {
+    //     const data = "0x420690";
+
+    //     const entry = strategy.decodeEntryParams(data);
+    //     const exit = strategy.decodeExitParams(data);
+
+    //     await expect(entry).to.be.revertedWith("CurveConvexStrategy: length en");
+    //     await expect(exit).to.be.revertedWith("CurveConvexStrategy: length ex");
+    // });
+
+    // it("Should execute full investment", async () => {
+    //     const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
+    //     const poolToken: IERC20Metadata = frax;
+    //     const poolSize = 3;
+    //     const tokenIndexInCurve = 0;
+    //     const convexPoolId = 58;
+    //     const amount = parseUnits("1000.0", await poolToken.decimals());
+
+    //     const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+    //     const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+    //     const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+    //     const exitData = await strategy.encodeExitParams(
+    //         curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
+    //     )
+    //     const entryData = await strategy.encodeEntryParams(
+    //         curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
+    //     );
+
+    //     expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+
+    //     const investBefore = await rewardPool.balanceOf(strategy.address);
+    //     await poolToken.transfer(strategy.address, amount);
+    //     const returnData = await strategy.callStatic.invest(entryData, amount);
+    //     await strategy.invest(entryData, amount);
+    //     const investAfter = await rewardPool.balanceOf(strategy.address);
+
+    //     expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(investAfter).to.be.gt(investBefore);
+    //     expect(returnData).to.be.equal(exitData);
+    // });
+
+    // it("Should execute investment only for Curve", async () => {
+    //     const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
+    //     const poolToken: IERC20Metadata = frax;
+    //     const poolSize = 3;
+    //     const tokenIndexInCurve = 0;
+    //     const convexPoolId = ethers.constants.MaxUint256;
+    //     const amount = parseUnits("1000.0", await poolToken.decimals());
+    //     const lpToken = await ethers.getContractAt("IERC20Metadata", curvePool)
+    //     const entryData = await strategy.encodeEntryParams(
+    //         curvePool, curvePool, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
+    //     );
+
+    //     const lpBalanceBefore = await lpToken.balanceOf(strategy.address);
+    //     await poolToken.transfer(strategy.address, amount);
+    //     await strategy.invest(entryData, amount);
+    //     const lpBalanceAfter = await lpToken.balanceOf(strategy.address);
+
+    //     expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(lpBalanceAfter).to.be.gt(lpBalanceBefore);
+    // });
+
+    // it("Should unwind investment", async () => {
+    //     const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
+    //     const poolToken: IERC20Metadata = frax;
+    //     const exitToken: IERC20Metadata = usdc;
+    //     const poolSize = 3;
+    //     const tokenIndexInCurve = 0;
+    //     const convexPoolId = 58;
+    //     const amount = parseUnits("1000.0", await poolToken.decimals());
+    //     const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+    //     const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+    //     const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+
+    //     const entryData = await strategy.encodeEntryParams(
+    //         curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
+    //     );
+    //     const exitData = await strategy.encodeExitParams(
+    //         curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
+    //     );
+
+    //     await poolToken.transfer(strategy.address, amount);
+    //     await strategy.invest(entryData, amount);
+
+    //     const balanceBefore = await exitToken.balanceOf(signers[0].address);
+    //     await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, true);
+    //     const balanceAfter = await exitToken.balanceOf(signers[0].address);
+
+    //     expect(balanceAfter).to.be.gt(balanceBefore);
+    //     expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await rewardPool.balanceOf(strategy.address)).to.be.equal(0);
+
+    //     expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await crv.balanceOf(signers[0].address)).to.be.equal(0);
+    //     expect(await cvx.balanceOf(signers[0].address)).to.be.equal(0);
+    // })
+
+    // it("Should unwind investment without Convex", async () => {
+    //     const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
+    //     const poolToken: IERC20Metadata = frax;
+    //     const exitToken: IERC20Metadata = usdc;
+    //     const poolSize = 3;
+    //     const tokenIndexInCurve = 0;
+    //     const convexPoolId = ethers.constants.MaxUint256;
+    //     const amount = parseUnits("1000.0", await poolToken.decimals());
+
+    //     const entryData = await strategy.encodeEntryParams(
+    //         curvePool, curvePool, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
+    //     );
+    //     const exitData = await strategy.encodeExitParams(
+    //         curvePool, poolToken.address, curvePool, tokenIndexInCurve, convexPoolId
+    //     );
+
+    //     await poolToken.transfer(strategy.address, amount);
+    //     await strategy.invest(entryData, amount);
+
+    //     const balanceBefore = await exitToken.balanceOf(signers[0].address);
+    //     await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, true);
+    //     const balanceAfter = await exitToken.balanceOf(signers[0].address);
+
+    //     expect(balanceAfter).to.be.gt(balanceBefore);
+    //     expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
+
+    //     expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await crv.balanceOf(signers[0].address)).to.be.equal(0);
+    //     expect(await cvx.balanceOf(signers[0].address)).to.be.equal(0);
+    // })
+
+    // it("Should unwind investment (without rewards swap)", async () => {
+    //     const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
+    //     const poolToken: IERC20Metadata = frax;
+    //     const exitToken: IERC20Metadata = usdc;
+    //     const poolSize = 3;
+    //     const tokenIndexInCurve = 0;
+    //     const convexPoolId = 58;
+    //     const amount = parseUnits("1000.0", await poolToken.decimals());
+    //     const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+    //     const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+    //     const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+
+    //     const entryData = await strategy.encodeEntryParams(
+    //         curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
+    //     );
+    //     const exitData = await strategy.encodeExitParams(
+    //         curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
+    //     );
+
+    //     await poolToken.transfer(strategy.address, amount);
+    //     await strategy.invest(entryData, amount);
+
+    //     const cvxBalanceBefore = await cvx.balanceOf(signers[0].address);
+    //     const crvBalanceBefore = await crv.balanceOf(signers[0].address);
+    //     const balanceBefore = await exitToken.balanceOf(signers[0].address);
+    //     await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, false);
+    //     const balanceAfter = await exitToken.balanceOf(signers[0].address);
+    //     const cvxBalanceAfter = await cvx.balanceOf(signers[0].address);
+    //     const crvBalanceAfter = await crv.balanceOf(signers[0].address);
+
+    //     expect(balanceAfter).to.be.gt(balanceBefore);
+    //     expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await rewardPool.balanceOf(strategy.address)).to.be.equal(0);
+
+    //     expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(crvBalanceAfter).to.be.gt(crvBalanceBefore);
+    //     expect(cvxBalanceAfter).to.be.gt(cvxBalanceBefore);
+    // })
+
+    // it("Should only claim rewards", async () => {
+    //     const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
+    //     const poolToken: IERC20Metadata = frax;
+    //     const exitToken: IERC20Metadata = usdc;
+    //     const poolSize = 3;
+    //     const tokenIndexInCurve = 0;
+    //     const convexPoolId = 58;
+    //     const amount = parseUnits("1000.0", await poolToken.decimals());
+    //     const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+    //     const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+    //     const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+
+    //     const entryData = await strategy.encodeEntryParams(
+    //         curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
+    //     );
+    //     const exitData = await strategy.encodeExitParams(
+    //         curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
+    //     );
+
+    //     await poolToken.transfer(strategy.address, amount);
+    //     await strategy.invest(entryData, amount);
+
+    //     const lpBalanceBefore = await rewardPool.balanceOf(strategy.address);
+    //     const coinBalanceBefore = await exitToken.balanceOf(signers[0].address);
+    //     await strategy.exitOnlyRewards(exitData, exitToken.address, signers[0].address, true);
+    //     const lpBalanceAfter = await rewardPool.balanceOf(strategy.address);
+    //     const coinBalanceAfter = await exitToken.balanceOf(signers[0].address);
+
+    //     expect(lpBalanceBefore).to.not.be.equal(0);
+    //     expect(lpBalanceBefore).to.be.equal(lpBalanceAfter);
+    //     expect(coinBalanceAfter).to.be.gt(coinBalanceBefore);
+    // })
+
+    describe("Testing with Native ETH", async () => {
+        it("Should execute full investment", async () => {
+            const curvePool = "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022";
+            const poolToken: IERC20Metadata = weth;
+            const poolSize = 2;
+            const tokenIndexInCurve = 0;
+            const convexPoolId = 25;
+            const amount = parseUnits("100.0", await poolToken.decimals());
+
+            const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+            const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+            const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+            const exitData = await strategy.encodeExitParams(
+                curvePool, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", lpToken.address, tokenIndexInCurve, convexPoolId
+            )
+            const entryData = await strategy.encodeEntryParams(
+                curvePool, lpToken.address, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", poolSize, tokenIndexInCurve, convexPoolId
+            );
+    
+            expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+    
+            const investBefore = await rewardPool.balanceOf(strategy.address);
+            await poolToken.transfer(strategy.address, amount);
+
+            const returnData = await strategy.callStatic.invest(entryData, amount);
+            await strategy.invest(entryData, amount);
+            const investAfter = await rewardPool.balanceOf(strategy.address);
+    
+            expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+            expect(investAfter).to.be.gt(investBefore);
+            expect(returnData).to.be.equal(exitData);
+        });
+    
+        it("Should execute investment only for Curve", async () => {
+
+            const curvePool = "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022";
+            const poolToken: IERC20Metadata = weth;
+            const poolSize = 2;
+            const tokenIndexInCurve = 0;
+            const convexPoolId = ethers.constants.MaxUint256;
+            const amount = parseUnits("100.0", await poolToken.decimals());
+    
+            
+            const poolInfo = await cvxBooster.poolInfo(25);
+            const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+            const entryData = await strategy.encodeEntryParams(
+                curvePool, lpToken.address, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", poolSize, tokenIndexInCurve, convexPoolId
+            );
+    
+            const lpBalanceBefore = await lpToken.balanceOf(strategy.address);
+            await poolToken.transfer(strategy.address, amount);
+            await strategy.invest(entryData, amount);
+            const lpBalanceAfter = await lpToken.balanceOf(strategy.address);
+    
+            expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+            expect(lpBalanceAfter).to.be.gt(lpBalanceBefore);
+        });
+    
+        it("Should unwind investment", async () => {
+
+            const curvePool = "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022";
+            const poolToken: IERC20Metadata = weth;
+            const exitToken: IERC20Metadata = weth;
+            const poolSize = 2;
+            const tokenIndexInCurve = 0;
+            const convexPoolId = 25;
+            const amount = parseUnits("100.0", await poolToken.decimals());
+
+            const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+            const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+            const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+    
+            const entryData = await strategy.encodeEntryParams(
+                curvePool, lpToken.address, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", poolSize, tokenIndexInCurve, convexPoolId
+            );
+            const exitData = await strategy.encodeExitParams(
+                curvePool, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", lpToken.address, tokenIndexInCurve, convexPoolId
+            );
+    
+            await poolToken.transfer(strategy.address, amount);
+            await strategy.invest(entryData, amount);
+    
+            const balanceBefore = await exitToken.balanceOf(signers[0].address);
+            await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, true);
+            const balanceAfter = await exitToken.balanceOf(signers[0].address);
+    
+            expect(balanceAfter).to.be.gt(balanceBefore);
+            expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await rewardPool.balanceOf(strategy.address)).to.be.equal(0);
+    
+            expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await crv.balanceOf(signers[0].address)).to.be.equal(0);
+            expect(await cvx.balanceOf(signers[0].address)).to.be.equal(0);
+        })
+    
+        it("Should unwind investment without Convex", async () => {
+
+            const curvePool = "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022";
+            const poolToken: IERC20Metadata = weth;
+            const exitToken: IERC20Metadata = weth;
+            const poolSize = 2;
+            const tokenIndexInCurve = 0;
+            const amount = parseUnits("100.0", await poolToken.decimals());
+            const convexPoolId = ethers.constants.MaxUint256;
+            const poolInfo = await cvxBooster.poolInfo(25);
+            const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+            const entryData = await strategy.encodeEntryParams(
+                curvePool, lpToken.address, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", poolSize, tokenIndexInCurve, convexPoolId
+            );
+            const exitData = await strategy.encodeExitParams(
+                curvePool, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", lpToken.address, tokenIndexInCurve, convexPoolId
+            );
+    
+            await poolToken.transfer(strategy.address, amount);
+            await strategy.invest(entryData, amount);
+    
+            const balanceBefore = await exitToken.balanceOf(signers[0].address);
+            await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, true);
+            const balanceAfter = await exitToken.balanceOf(signers[0].address);
+    
+            expect(balanceAfter).to.be.gt(balanceBefore);
+            expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
+    
+            expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await crv.balanceOf(signers[0].address)).to.be.equal(0);
+            expect(await cvx.balanceOf(signers[0].address)).to.be.equal(0);
+        })
+    
+        it("Should unwind investment (without rewards swap)", async () => {
+
+            const curvePool = "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022";
+            const poolToken: IERC20Metadata = weth;
+            const exitToken: IERC20Metadata = weth;
+            const poolSize = 2;
+            const tokenIndexInCurve = 0;
+            const convexPoolId = 25;
+            const amount = parseUnits("100.0", await poolToken.decimals());
+
+        
+            const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+            const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+            const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+    
+            const entryData = await strategy.encodeEntryParams(
+                curvePool, lpToken.address, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", poolSize, tokenIndexInCurve, convexPoolId
+            );
+            const exitData = await strategy.encodeExitParams(
+                curvePool, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", lpToken.address, tokenIndexInCurve, convexPoolId
+            );
+    
+            await poolToken.transfer(strategy.address, amount);
+            await strategy.invest(entryData, amount);
+    
+            const cvxBalanceBefore = await cvx.balanceOf(signers[0].address);
+            const crvBalanceBefore = await crv.balanceOf(signers[0].address);
+            const balanceBefore = await exitToken.balanceOf(signers[0].address);
+            await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, false);
+            const balanceAfter = await exitToken.balanceOf(signers[0].address);
+            const cvxBalanceAfter = await cvx.balanceOf(signers[0].address);
+            const crvBalanceAfter = await crv.balanceOf(signers[0].address);
+    
+            expect(balanceAfter).to.be.gt(balanceBefore);
+            expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await rewardPool.balanceOf(strategy.address)).to.be.equal(0);
+    
+            expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
+            expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
+            expect(crvBalanceAfter).to.be.gt(crvBalanceBefore);
+            expect(cvxBalanceAfter).to.be.gt(cvxBalanceBefore);
+        })
+    
+        it("Should only claim rewards", async () => {
+            const curvePool = "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022";
+            const poolToken: IERC20Metadata = weth;
+            const exitToken: IERC20Metadata = weth;
+            const poolSize = 2;
+            const tokenIndexInCurve = 0;
+            const convexPoolId = 25;
+            const amount = parseUnits("100.0", await poolToken.decimals());
+
+
+            const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+            const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+            const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+    
+            const entryData = await strategy.encodeEntryParams(
+                curvePool, lpToken.address, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", poolSize, tokenIndexInCurve, convexPoolId
+            );
+            const exitData = await strategy.encodeExitParams(
+                curvePool, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", lpToken.address, tokenIndexInCurve, convexPoolId
+            );
+    
+            await poolToken.transfer(strategy.address, amount);
+            await strategy.invest(entryData, amount);
+    
+            const lpBalanceBefore = await rewardPool.balanceOf(strategy.address);
+            const coinBalanceBefore = await exitToken.balanceOf(signers[0].address);
+            await strategy.exitOnlyRewards(exitData, exitToken.address, signers[0].address, true);
+            const lpBalanceAfter = await rewardPool.balanceOf(strategy.address);
+            const coinBalanceAfter = await exitToken.balanceOf(signers[0].address);
+    
+            expect(lpBalanceBefore).to.not.be.equal(0);
+            expect(lpBalanceBefore).to.be.equal(lpBalanceAfter);
+            expect(coinBalanceAfter).to.be.gt(coinBalanceBefore);
+        })
     })
-
-    it("Should check roles", async () => {
-        const contract = usdc.address;
-        const roleError = `AccessControl: account ${signers[0].address.toLowerCase()} is missing role ${ethers.constants.HashZero}`;
-
-        const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
-        const newStrategy = await Strategy.deploy(contract, contract, false);
-
-        await expect(newStrategy.invest("0x", 0)).to.be.revertedWith(roleError);
-        await expect(newStrategy.exitAll("0x", 0, contract, contract, true)).to.be.revertedWith(roleError);
-        await expect(newStrategy.exitOnlyRewards("0x", contract, contract, true)).to.be.revertedWith(roleError);
-        await expect(newStrategy.multicall([], [])).to.be.revertedWith(roleError);
-    });
-
-    it("Should check correct encoders/decoders", async () => {
-        const curvePool = "0x0000000000000000000000000000000000000001";
-        const poolToken = "0x0000000000000000000000000000000000000002";
-        const poolSize = 3;
-        const tokenIndexInCurve = 4;
-        const convexPoolId = 5;
-        const lpToken = "0x0000000000000000000000000000000000000006"
-
-        const entry = defaultAbiCoder.encode(
-            ["address", "address ", "address", "uint8", "uint8", "uint256"],
-            [curvePool, lpToken, poolToken, poolSize, tokenIndexInCurve, convexPoolId]
-        )
-        const exit = defaultAbiCoder.encode(
-            ["address", "address", "address", "uint8", "uint256"],
-            [curvePool, poolToken, lpToken, tokenIndexInCurve, convexPoolId]
-        );
-
-        expect(await strategy.encodeEntryParams(
-            curvePool, lpToken, poolToken, poolSize, tokenIndexInCurve, convexPoolId
-        )).to.be.equal(entry);
-
-        expect(await strategy.encodeExitParams(
-            curvePool, poolToken, lpToken, tokenIndexInCurve, convexPoolId
-        )).to.be.equal(exit);
-
-        const entryStruct = await strategy.decodeEntryParams(entry);
-        const exitStruct = await strategy.decodeExitParams(exit);
-
-        expect(entryStruct[0]).to.be.equal(curvePool);
-        expect(entryStruct[1]).to.be.equal(lpToken);
-        expect(entryStruct[2]).to.be.equal(poolToken);
-        expect(entryStruct[3]).to.be.equal(poolSize);
-        expect(entryStruct[4]).to.be.equal(tokenIndexInCurve);
-        expect(entryStruct[5]).to.be.equal(convexPoolId);
-
-        expect(exitStruct[0]).to.be.equal(curvePool);
-        expect(exitStruct[1]).to.be.equal(poolToken);
-        expect(exitStruct[2]).to.be.equal(lpToken);
-        expect(exitStruct[3]).to.be.equal(tokenIndexInCurve);
-        expect(exitStruct[4]).to.be.equal(convexPoolId);
-    });
-
-    it("Should revert decoders if data length is wrong", async () => {
-        const data = "0x420690";
-
-        const entry = strategy.decodeEntryParams(data);
-        const exit = strategy.decodeExitParams(data);
-
-        await expect(entry).to.be.revertedWith("CurveConvexStrategy: length en");
-        await expect(exit).to.be.revertedWith("CurveConvexStrategy: length ex");
-    });
-
-    it("Should execute full investment", async () => {
-        const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
-        const poolToken: IERC20Metadata = frax;
-        const poolSize = 3;
-        const tokenIndexInCurve = 0;
-        const convexPoolId = 58;
-        const amount = parseUnits("1000.0", await poolToken.decimals());
-
-        const poolInfo = await cvxBooster.poolInfo(convexPoolId);
-        const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
-        const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
-        const exitData = await strategy.encodeExitParams(
-            curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
-        )
-        const entryData = await strategy.encodeEntryParams(
-            curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
-        );
-
-        expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
-
-        const investBefore = await rewardPool.balanceOf(strategy.address);
-        await poolToken.transfer(strategy.address, amount);
-        const returnData = await strategy.callStatic.invest(entryData, amount);
-        await strategy.invest(entryData, amount);
-        const investAfter = await rewardPool.balanceOf(strategy.address);
-
-        expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
-        expect(investAfter).to.be.gt(investBefore);
-        expect(returnData).to.be.equal(exitData);
-    });
-
-    it("Should execute investment only for Curve", async () => {
-        const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
-        const poolToken: IERC20Metadata = frax;
-        const poolSize = 3;
-        const tokenIndexInCurve = 0;
-        const convexPoolId = ethers.constants.MaxUint256;
-        const amount = parseUnits("1000.0", await poolToken.decimals());
-        const lpToken = await ethers.getContractAt("IERC20Metadata", curvePool)
-        const entryData = await strategy.encodeEntryParams(
-            curvePool, curvePool, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
-        );
-
-        const lpBalanceBefore = await lpToken.balanceOf(strategy.address);
-        await poolToken.transfer(strategy.address, amount);
-        await strategy.invest(entryData, amount);
-        const lpBalanceAfter = await lpToken.balanceOf(strategy.address);
-
-        expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
-        expect(lpBalanceAfter).to.be.gt(lpBalanceBefore);
-    });
-
-    it("Should unwind investment", async () => {
-        const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
-        const poolToken: IERC20Metadata = frax;
-        const exitToken: IERC20Metadata = usdc;
-        const poolSize = 3;
-        const tokenIndexInCurve = 0;
-        const convexPoolId = 58;
-        const amount = parseUnits("1000.0", await poolToken.decimals());
-        const poolInfo = await cvxBooster.poolInfo(convexPoolId);
-        const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
-        const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
-
-        const entryData = await strategy.encodeEntryParams(
-            curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
-        );
-        const exitData = await strategy.encodeExitParams(
-            curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
-        );
-
-        await poolToken.transfer(strategy.address, amount);
-        await strategy.invest(entryData, amount);
-
-        const balanceBefore = await exitToken.balanceOf(signers[0].address);
-        await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, true);
-        const balanceAfter = await exitToken.balanceOf(signers[0].address);
-
-        expect(balanceAfter).to.be.gt(balanceBefore);
-        expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await rewardPool.balanceOf(strategy.address)).to.be.equal(0);
-
-        expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await crv.balanceOf(signers[0].address)).to.be.equal(0);
-        expect(await cvx.balanceOf(signers[0].address)).to.be.equal(0);
-    })
-
-    it("Should unwind investment without Convex", async () => {
-        const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
-        const poolToken: IERC20Metadata = frax;
-        const exitToken: IERC20Metadata = usdc;
-        const poolSize = 3;
-        const tokenIndexInCurve = 0;
-        const convexPoolId = ethers.constants.MaxUint256;
-        const amount = parseUnits("1000.0", await poolToken.decimals());
-
-        const entryData = await strategy.encodeEntryParams(
-            curvePool, curvePool, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
-        );
-        const exitData = await strategy.encodeExitParams(
-            curvePool, poolToken.address, curvePool, tokenIndexInCurve, convexPoolId
-        );
-
-        await poolToken.transfer(strategy.address, amount);
-        await strategy.invest(entryData, amount);
-
-        const balanceBefore = await exitToken.balanceOf(signers[0].address);
-        await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, true);
-        const balanceAfter = await exitToken.balanceOf(signers[0].address);
-
-        expect(balanceAfter).to.be.gt(balanceBefore);
-        expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
-
-        expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await crv.balanceOf(signers[0].address)).to.be.equal(0);
-        expect(await cvx.balanceOf(signers[0].address)).to.be.equal(0);
-    })
-
-    it("Should unwind investment (without rewards swap)", async () => {
-        const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
-        const poolToken: IERC20Metadata = frax;
-        const exitToken: IERC20Metadata = usdc;
-        const poolSize = 3;
-        const tokenIndexInCurve = 0;
-        const convexPoolId = 58;
-        const amount = parseUnits("1000.0", await poolToken.decimals());
-        const poolInfo = await cvxBooster.poolInfo(convexPoolId);
-        const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
-        const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
-
-        const entryData = await strategy.encodeEntryParams(
-            curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
-        );
-        const exitData = await strategy.encodeExitParams(
-            curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
-        );
-
-        await poolToken.transfer(strategy.address, amount);
-        await strategy.invest(entryData, amount);
-
-        const cvxBalanceBefore = await cvx.balanceOf(signers[0].address);
-        const crvBalanceBefore = await crv.balanceOf(signers[0].address);
-        const balanceBefore = await exitToken.balanceOf(signers[0].address);
-        await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, false);
-        const balanceAfter = await exitToken.balanceOf(signers[0].address);
-        const cvxBalanceAfter = await cvx.balanceOf(signers[0].address);
-        const crvBalanceAfter = await crv.balanceOf(signers[0].address);
-
-        expect(balanceAfter).to.be.gt(balanceBefore);
-        expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await rewardPool.balanceOf(strategy.address)).to.be.equal(0);
-
-        expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
-        expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
-        expect(crvBalanceAfter).to.be.gt(crvBalanceBefore);
-        expect(cvxBalanceAfter).to.be.gt(cvxBalanceBefore);
-    })
-
-    it("Should only claim rewards", async () => {
-        const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
-        const poolToken: IERC20Metadata = frax;
-        const exitToken: IERC20Metadata = usdc;
-        const poolSize = 3;
-        const tokenIndexInCurve = 0;
-        const convexPoolId = 58;
-        const amount = parseUnits("1000.0", await poolToken.decimals());
-        const poolInfo = await cvxBooster.poolInfo(convexPoolId);
-        const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
-        const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
-
-        const entryData = await strategy.encodeEntryParams(
-            curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
-        );
-        const exitData = await strategy.encodeExitParams(
-            curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
-        );
-
-        await poolToken.transfer(strategy.address, amount);
-        await strategy.invest(entryData, amount);
-
-        const lpBalanceBefore = await rewardPool.balanceOf(strategy.address);
-        const coinBalanceBefore = await exitToken.balanceOf(signers[0].address);
-        await strategy.exitOnlyRewards(exitData, exitToken.address, signers[0].address, true);
-        const lpBalanceAfter = await rewardPool.balanceOf(strategy.address);
-        const coinBalanceAfter = await exitToken.balanceOf(signers[0].address);
-
-        expect(lpBalanceBefore).to.not.be.equal(0);
-        expect(lpBalanceBefore).to.be.equal(lpBalanceAfter);
-        expect(coinBalanceAfter).to.be.gt(coinBalanceBefore);
-    })
-
     it("Should execute mulicall", async () => {
         const token = frax;
         const amount = parseUnits("200.0", await token.decimals());

--- a/test/CurveConvexStrategy.ts
+++ b/test/CurveConvexStrategy.ts
@@ -45,313 +45,313 @@ describe("CurveConvexStrategy", function () {
         await wrappedEther.deposit({value: ethers.utils.parseEther("100")})
     });
 
-    // it("Should check initial contract state", async () => {
-    //     const cvxBooster = "0xF403C135812408BFbE8713b5A23a04b3D48AAE31";
-    //     const exchange = "0x29c66CF57a03d41Cfe6d9ecB6883aa0E2AbA21Ec";
-    //     const cvxRewards = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
-    //     const crvRewards = "0xD533a949740bb3306d119CC777fa900bA034cd52";
-    //     const unwindDecimals = 2;
-    //     const adminRole = await strategy.DEFAULT_ADMIN_ROLE();
+    it("Should check initial contract state", async () => {
+        const cvxBooster = "0xF403C135812408BFbE8713b5A23a04b3D48AAE31";
+        const exchange = "0x29c66CF57a03d41Cfe6d9ecB6883aa0E2AbA21Ec";
+        const cvxRewards = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+        const crvRewards = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+        const unwindDecimals = 2;
+        const adminRole = await strategy.DEFAULT_ADMIN_ROLE();
 
-    //     expect(await strategy.cvxBooster()).to.be.equal(cvxBooster);
-    //     expect(await strategy.exchange()).to.be.equal(exchange);
-    //     expect(await strategy.cvxRewards()).to.be.equal(cvxRewards);
-    //     expect(await strategy.crvRewards()).to.be.equal(crvRewards);
-    //     expect(await strategy.unwindDecimals()).to.be.equal(unwindDecimals);
+        expect(await strategy.cvxBooster()).to.be.equal(cvxBooster);
+        expect(await strategy.exchange()).to.be.equal(exchange);
+        expect(await strategy.cvxRewards()).to.be.equal(cvxRewards);
+        expect(await strategy.crvRewards()).to.be.equal(crvRewards);
+        expect(await strategy.unwindDecimals()).to.be.equal(unwindDecimals);
 
-    //     expect(await strategy.hasRole(adminRole, signers[0].address)).to.be.true;
-    // });
+        expect(await strategy.hasRole(adminRole, signers[0].address)).to.be.true;
+    });
 
-    // it("Should check initial contract state (testing == false)", async () => {
-    //     const contract1 = usdc.address;
-    //     const contract2 = usdt.address;
-    //     const adminRole = ethers.constants.HashZero;
+    it("Should check initial contract state (testing == false)", async () => {
+        const contract1 = usdc.address;
+        const contract2 = usdt.address;
+        const adminRole = ethers.constants.HashZero;
 
-    //     expect(contract1).to.not.be.equal(contract2);
+        expect(contract1).to.not.be.equal(contract2);
 
-    //     const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
-    //     const newStrategy = await Strategy.deploy(contract1, contract2, false);
+        const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
+        const newStrategy = await Strategy.deploy(contract1, contract2, false);
 
-    //     expect(await newStrategy.hasRole(adminRole, contract1)).to.be.true;
-    //     expect(await newStrategy.hasRole(adminRole, contract2)).to.be.true;
-    // });
+        expect(await newStrategy.hasRole(adminRole, contract1)).to.be.true;
+        expect(await newStrategy.hasRole(adminRole, contract2)).to.be.true;
+    });
 
-    // it("Should not deploy contract (gnosis/voteExecutor not contract)", async () => {
-    //     const notContract = signers[1].address;
-    //     const contract = usdc.address;
+    it("Should not deploy contract (gnosis/voteExecutor not contract)", async () => {
+        const notContract = signers[1].address;
+        const contract = usdc.address;
 
-    //     const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
+        const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
 
-    //     let newStrategy = Strategy.deploy(notContract, contract, false);
-    //     await expect(newStrategy).to.be.revertedWith("CurveConvexStrategy: 1!contract");
+        let newStrategy = Strategy.deploy(notContract, contract, false);
+        await expect(newStrategy).to.be.revertedWith("CurveConvexStrategy: 1!contract");
 
-    //     newStrategy = Strategy.deploy(contract, notContract, false);
-    //     await expect(newStrategy).to.be.revertedWith("CurveConvexStrategy: 2!contract");
-    // })
+        newStrategy = Strategy.deploy(contract, notContract, false);
+        await expect(newStrategy).to.be.revertedWith("CurveConvexStrategy: 2!contract");
+    })
 
-    // it("Should check roles", async () => {
-    //     const contract = usdc.address;
-    //     const roleError = `AccessControl: account ${signers[0].address.toLowerCase()} is missing role ${ethers.constants.HashZero}`;
+    it("Should check roles", async () => {
+        const contract = usdc.address;
+        const roleError = `AccessControl: account ${signers[0].address.toLowerCase()} is missing role ${ethers.constants.HashZero}`;
 
-    //     const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
-    //     const newStrategy = await Strategy.deploy(contract, contract, false);
+        const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
+        const newStrategy = await Strategy.deploy(contract, contract, false);
 
-    //     await expect(newStrategy.invest("0x", 0)).to.be.revertedWith(roleError);
-    //     await expect(newStrategy.exitAll("0x", 0, contract, contract, true)).to.be.revertedWith(roleError);
-    //     await expect(newStrategy.exitOnlyRewards("0x", contract, contract, true)).to.be.revertedWith(roleError);
-    //     await expect(newStrategy.multicall([], [])).to.be.revertedWith(roleError);
-    // });
+        await expect(newStrategy.invest("0x", 0)).to.be.revertedWith(roleError);
+        await expect(newStrategy.exitAll("0x", 0, contract, contract, true)).to.be.revertedWith(roleError);
+        await expect(newStrategy.exitOnlyRewards("0x", contract, contract, true)).to.be.revertedWith(roleError);
+        await expect(newStrategy.multicall([], [])).to.be.revertedWith(roleError);
+    });
 
-    // it("Should check correct encoders/decoders", async () => {
-    //     const curvePool = "0x0000000000000000000000000000000000000001";
-    //     const poolToken = "0x0000000000000000000000000000000000000002";
-    //     const poolSize = 3;
-    //     const tokenIndexInCurve = 4;
-    //     const convexPoolId = 5;
-    //     const lpToken = "0x0000000000000000000000000000000000000006"
+    it("Should check correct encoders/decoders", async () => {
+        const curvePool = "0x0000000000000000000000000000000000000001";
+        const poolToken = "0x0000000000000000000000000000000000000002";
+        const poolSize = 3;
+        const tokenIndexInCurve = 4;
+        const convexPoolId = 5;
+        const lpToken = "0x0000000000000000000000000000000000000006"
 
-    //     const entry = defaultAbiCoder.encode(
-    //         ["address", "address ", "address", "uint8", "uint8", "uint256"],
-    //         [curvePool, lpToken, poolToken, poolSize, tokenIndexInCurve, convexPoolId]
-    //     )
-    //     const exit = defaultAbiCoder.encode(
-    //         ["address", "address", "address", "uint8", "uint256"],
-    //         [curvePool, poolToken, lpToken, tokenIndexInCurve, convexPoolId]
-    //     );
+        const entry = defaultAbiCoder.encode(
+            ["address", "address ", "address", "uint8", "uint8", "uint256"],
+            [curvePool, lpToken, poolToken, poolSize, tokenIndexInCurve, convexPoolId]
+        )
+        const exit = defaultAbiCoder.encode(
+            ["address", "address", "address", "uint8", "uint256"],
+            [curvePool, poolToken, lpToken, tokenIndexInCurve, convexPoolId]
+        );
 
-    //     expect(await strategy.encodeEntryParams(
-    //         curvePool, lpToken, poolToken, poolSize, tokenIndexInCurve, convexPoolId
-    //     )).to.be.equal(entry);
+        expect(await strategy.encodeEntryParams(
+            curvePool, lpToken, poolToken, poolSize, tokenIndexInCurve, convexPoolId
+        )).to.be.equal(entry);
 
-    //     expect(await strategy.encodeExitParams(
-    //         curvePool, poolToken, lpToken, tokenIndexInCurve, convexPoolId
-    //     )).to.be.equal(exit);
+        expect(await strategy.encodeExitParams(
+            curvePool, poolToken, lpToken, tokenIndexInCurve, convexPoolId
+        )).to.be.equal(exit);
 
-    //     const entryStruct = await strategy.decodeEntryParams(entry);
-    //     const exitStruct = await strategy.decodeExitParams(exit);
+        const entryStruct = await strategy.decodeEntryParams(entry);
+        const exitStruct = await strategy.decodeExitParams(exit);
 
-    //     expect(entryStruct[0]).to.be.equal(curvePool);
-    //     expect(entryStruct[1]).to.be.equal(lpToken);
-    //     expect(entryStruct[2]).to.be.equal(poolToken);
-    //     expect(entryStruct[3]).to.be.equal(poolSize);
-    //     expect(entryStruct[4]).to.be.equal(tokenIndexInCurve);
-    //     expect(entryStruct[5]).to.be.equal(convexPoolId);
+        expect(entryStruct[0]).to.be.equal(curvePool);
+        expect(entryStruct[1]).to.be.equal(lpToken);
+        expect(entryStruct[2]).to.be.equal(poolToken);
+        expect(entryStruct[3]).to.be.equal(poolSize);
+        expect(entryStruct[4]).to.be.equal(tokenIndexInCurve);
+        expect(entryStruct[5]).to.be.equal(convexPoolId);
 
-    //     expect(exitStruct[0]).to.be.equal(curvePool);
-    //     expect(exitStruct[1]).to.be.equal(poolToken);
-    //     expect(exitStruct[2]).to.be.equal(lpToken);
-    //     expect(exitStruct[3]).to.be.equal(tokenIndexInCurve);
-    //     expect(exitStruct[4]).to.be.equal(convexPoolId);
-    // });
+        expect(exitStruct[0]).to.be.equal(curvePool);
+        expect(exitStruct[1]).to.be.equal(poolToken);
+        expect(exitStruct[2]).to.be.equal(lpToken);
+        expect(exitStruct[3]).to.be.equal(tokenIndexInCurve);
+        expect(exitStruct[4]).to.be.equal(convexPoolId);
+    });
 
-    // it("Should revert decoders if data length is wrong", async () => {
-    //     const data = "0x420690";
+    it("Should revert decoders if data length is wrong", async () => {
+        const data = "0x420690";
 
-    //     const entry = strategy.decodeEntryParams(data);
-    //     const exit = strategy.decodeExitParams(data);
+        const entry = strategy.decodeEntryParams(data);
+        const exit = strategy.decodeExitParams(data);
 
-    //     await expect(entry).to.be.revertedWith("CurveConvexStrategy: length en");
-    //     await expect(exit).to.be.revertedWith("CurveConvexStrategy: length ex");
-    // });
+        await expect(entry).to.be.revertedWith("CurveConvexStrategy: length en");
+        await expect(exit).to.be.revertedWith("CurveConvexStrategy: length ex");
+    });
 
-    // it("Should execute full investment", async () => {
-    //     const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
-    //     const poolToken: IERC20Metadata = frax;
-    //     const poolSize = 3;
-    //     const tokenIndexInCurve = 0;
-    //     const convexPoolId = 58;
-    //     const amount = parseUnits("1000.0", await poolToken.decimals());
+    it("Should execute full investment", async () => {
+        const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
+        const poolToken: IERC20Metadata = frax;
+        const poolSize = 3;
+        const tokenIndexInCurve = 0;
+        const convexPoolId = 58;
+        const amount = parseUnits("1000.0", await poolToken.decimals());
 
-    //     const poolInfo = await cvxBooster.poolInfo(convexPoolId);
-    //     const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
-    //     const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
-    //     const exitData = await strategy.encodeExitParams(
-    //         curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
-    //     )
-    //     const entryData = await strategy.encodeEntryParams(
-    //         curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
-    //     );
+        const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+        const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+        const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+        const exitData = await strategy.encodeExitParams(
+            curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
+        )
+        const entryData = await strategy.encodeEntryParams(
+            curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
+        );
 
-    //     expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
 
-    //     const investBefore = await rewardPool.balanceOf(strategy.address);
-    //     await poolToken.transfer(strategy.address, amount);
-    //     const returnData = await strategy.callStatic.invest(entryData, amount);
-    //     await strategy.invest(entryData, amount);
-    //     const investAfter = await rewardPool.balanceOf(strategy.address);
+        const investBefore = await rewardPool.balanceOf(strategy.address);
+        await poolToken.transfer(strategy.address, amount);
+        const returnData = await strategy.callStatic.invest(entryData, amount);
+        await strategy.invest(entryData, amount);
+        const investAfter = await rewardPool.balanceOf(strategy.address);
 
-    //     expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(investAfter).to.be.gt(investBefore);
-    //     expect(returnData).to.be.equal(exitData);
-    // });
+        expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(investAfter).to.be.gt(investBefore);
+        expect(returnData).to.be.equal(exitData);
+    });
 
-    // it("Should execute investment only for Curve", async () => {
-    //     const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
-    //     const poolToken: IERC20Metadata = frax;
-    //     const poolSize = 3;
-    //     const tokenIndexInCurve = 0;
-    //     const convexPoolId = ethers.constants.MaxUint256;
-    //     const amount = parseUnits("1000.0", await poolToken.decimals());
-    //     const lpToken = await ethers.getContractAt("IERC20Metadata", curvePool)
-    //     const entryData = await strategy.encodeEntryParams(
-    //         curvePool, curvePool, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
-    //     );
+    it("Should execute investment only for Curve", async () => {
+        const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
+        const poolToken: IERC20Metadata = frax;
+        const poolSize = 3;
+        const tokenIndexInCurve = 0;
+        const convexPoolId = ethers.constants.MaxUint256;
+        const amount = parseUnits("1000.0", await poolToken.decimals());
+        const lpToken = await ethers.getContractAt("IERC20Metadata", curvePool)
+        const entryData = await strategy.encodeEntryParams(
+            curvePool, curvePool, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
+        );
 
-    //     const lpBalanceBefore = await lpToken.balanceOf(strategy.address);
-    //     await poolToken.transfer(strategy.address, amount);
-    //     await strategy.invest(entryData, amount);
-    //     const lpBalanceAfter = await lpToken.balanceOf(strategy.address);
+        const lpBalanceBefore = await lpToken.balanceOf(strategy.address);
+        await poolToken.transfer(strategy.address, amount);
+        await strategy.invest(entryData, amount);
+        const lpBalanceAfter = await lpToken.balanceOf(strategy.address);
 
-    //     expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(lpBalanceAfter).to.be.gt(lpBalanceBefore);
-    // });
+        expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(lpBalanceAfter).to.be.gt(lpBalanceBefore);
+    });
 
-    // it("Should unwind investment", async () => {
-    //     const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
-    //     const poolToken: IERC20Metadata = frax;
-    //     const exitToken: IERC20Metadata = usdc;
-    //     const poolSize = 3;
-    //     const tokenIndexInCurve = 0;
-    //     const convexPoolId = 58;
-    //     const amount = parseUnits("1000.0", await poolToken.decimals());
-    //     const poolInfo = await cvxBooster.poolInfo(convexPoolId);
-    //     const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
-    //     const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+    it("Should unwind investment", async () => {
+        const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
+        const poolToken: IERC20Metadata = frax;
+        const exitToken: IERC20Metadata = usdc;
+        const poolSize = 3;
+        const tokenIndexInCurve = 0;
+        const convexPoolId = 58;
+        const amount = parseUnits("1000.0", await poolToken.decimals());
+        const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+        const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+        const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
 
-    //     const entryData = await strategy.encodeEntryParams(
-    //         curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
-    //     );
-    //     const exitData = await strategy.encodeExitParams(
-    //         curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
-    //     );
+        const entryData = await strategy.encodeEntryParams(
+            curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
+        );
+        const exitData = await strategy.encodeExitParams(
+            curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
+        );
 
-    //     await poolToken.transfer(strategy.address, amount);
-    //     await strategy.invest(entryData, amount);
+        await poolToken.transfer(strategy.address, amount);
+        await strategy.invest(entryData, amount);
 
-    //     const balanceBefore = await exitToken.balanceOf(signers[0].address);
-    //     await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, true);
-    //     const balanceAfter = await exitToken.balanceOf(signers[0].address);
+        const balanceBefore = await exitToken.balanceOf(signers[0].address);
+        await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, true);
+        const balanceAfter = await exitToken.balanceOf(signers[0].address);
 
-    //     expect(balanceAfter).to.be.gt(balanceBefore);
-    //     expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await rewardPool.balanceOf(strategy.address)).to.be.equal(0);
+        expect(balanceAfter).to.be.gt(balanceBefore);
+        expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await rewardPool.balanceOf(strategy.address)).to.be.equal(0);
 
-    //     expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await crv.balanceOf(signers[0].address)).to.be.equal(0);
-    //     expect(await cvx.balanceOf(signers[0].address)).to.be.equal(0);
-    // })
+        expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await crv.balanceOf(signers[0].address)).to.be.equal(0);
+        expect(await cvx.balanceOf(signers[0].address)).to.be.equal(0);
+    })
 
-    // it("Should unwind investment without Convex", async () => {
-    //     const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
-    //     const poolToken: IERC20Metadata = frax;
-    //     const exitToken: IERC20Metadata = usdc;
-    //     const poolSize = 3;
-    //     const tokenIndexInCurve = 0;
-    //     const convexPoolId = ethers.constants.MaxUint256;
-    //     const amount = parseUnits("1000.0", await poolToken.decimals());
+    it("Should unwind investment without Convex", async () => {
+        const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
+        const poolToken: IERC20Metadata = frax;
+        const exitToken: IERC20Metadata = usdc;
+        const poolSize = 3;
+        const tokenIndexInCurve = 0;
+        const convexPoolId = ethers.constants.MaxUint256;
+        const amount = parseUnits("1000.0", await poolToken.decimals());
 
-    //     const entryData = await strategy.encodeEntryParams(
-    //         curvePool, curvePool, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
-    //     );
-    //     const exitData = await strategy.encodeExitParams(
-    //         curvePool, poolToken.address, curvePool, tokenIndexInCurve, convexPoolId
-    //     );
+        const entryData = await strategy.encodeEntryParams(
+            curvePool, curvePool, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
+        );
+        const exitData = await strategy.encodeExitParams(
+            curvePool, poolToken.address, curvePool, tokenIndexInCurve, convexPoolId
+        );
 
-    //     await poolToken.transfer(strategy.address, amount);
-    //     await strategy.invest(entryData, amount);
+        await poolToken.transfer(strategy.address, amount);
+        await strategy.invest(entryData, amount);
 
-    //     const balanceBefore = await exitToken.balanceOf(signers[0].address);
-    //     await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, true);
-    //     const balanceAfter = await exitToken.balanceOf(signers[0].address);
+        const balanceBefore = await exitToken.balanceOf(signers[0].address);
+        await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, true);
+        const balanceAfter = await exitToken.balanceOf(signers[0].address);
 
-    //     expect(balanceAfter).to.be.gt(balanceBefore);
-    //     expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(balanceAfter).to.be.gt(balanceBefore);
+        expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
 
-    //     expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await crv.balanceOf(signers[0].address)).to.be.equal(0);
-    //     expect(await cvx.balanceOf(signers[0].address)).to.be.equal(0);
-    // })
+        expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await crv.balanceOf(signers[0].address)).to.be.equal(0);
+        expect(await cvx.balanceOf(signers[0].address)).to.be.equal(0);
+    })
 
-    // it("Should unwind investment (without rewards swap)", async () => {
-    //     const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
-    //     const poolToken: IERC20Metadata = frax;
-    //     const exitToken: IERC20Metadata = usdc;
-    //     const poolSize = 3;
-    //     const tokenIndexInCurve = 0;
-    //     const convexPoolId = 58;
-    //     const amount = parseUnits("1000.0", await poolToken.decimals());
-    //     const poolInfo = await cvxBooster.poolInfo(convexPoolId);
-    //     const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
-    //     const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+    it("Should unwind investment (without rewards swap)", async () => {
+        const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
+        const poolToken: IERC20Metadata = frax;
+        const exitToken: IERC20Metadata = usdc;
+        const poolSize = 3;
+        const tokenIndexInCurve = 0;
+        const convexPoolId = 58;
+        const amount = parseUnits("1000.0", await poolToken.decimals());
+        const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+        const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+        const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
 
-    //     const entryData = await strategy.encodeEntryParams(
-    //         curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
-    //     );
-    //     const exitData = await strategy.encodeExitParams(
-    //         curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
-    //     );
+        const entryData = await strategy.encodeEntryParams(
+            curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
+        );
+        const exitData = await strategy.encodeExitParams(
+            curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
+        );
 
-    //     await poolToken.transfer(strategy.address, amount);
-    //     await strategy.invest(entryData, amount);
+        await poolToken.transfer(strategy.address, amount);
+        await strategy.invest(entryData, amount);
 
-    //     const cvxBalanceBefore = await cvx.balanceOf(signers[0].address);
-    //     const crvBalanceBefore = await crv.balanceOf(signers[0].address);
-    //     const balanceBefore = await exitToken.balanceOf(signers[0].address);
-    //     await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, false);
-    //     const balanceAfter = await exitToken.balanceOf(signers[0].address);
-    //     const cvxBalanceAfter = await cvx.balanceOf(signers[0].address);
-    //     const crvBalanceAfter = await crv.balanceOf(signers[0].address);
+        const cvxBalanceBefore = await cvx.balanceOf(signers[0].address);
+        const crvBalanceBefore = await crv.balanceOf(signers[0].address);
+        const balanceBefore = await exitToken.balanceOf(signers[0].address);
+        await strategy.exitAll(exitData, 10000, exitToken.address, signers[0].address, false);
+        const balanceAfter = await exitToken.balanceOf(signers[0].address);
+        const cvxBalanceAfter = await cvx.balanceOf(signers[0].address);
+        const crvBalanceAfter = await crv.balanceOf(signers[0].address);
 
-    //     expect(balanceAfter).to.be.gt(balanceBefore);
-    //     expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await rewardPool.balanceOf(strategy.address)).to.be.equal(0);
+        expect(balanceAfter).to.be.gt(balanceBefore);
+        expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await exitToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await rewardPool.balanceOf(strategy.address)).to.be.equal(0);
 
-    //     expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
-    //     expect(crvBalanceAfter).to.be.gt(crvBalanceBefore);
-    //     expect(cvxBalanceAfter).to.be.gt(cvxBalanceBefore);
-    // })
+        expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
+        expect(crvBalanceAfter).to.be.gt(crvBalanceBefore);
+        expect(cvxBalanceAfter).to.be.gt(cvxBalanceBefore);
+    })
 
-    // it("Should only claim rewards", async () => {
-    //     const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
-    //     const poolToken: IERC20Metadata = frax;
-    //     const exitToken: IERC20Metadata = usdc;
-    //     const poolSize = 3;
-    //     const tokenIndexInCurve = 0;
-    //     const convexPoolId = 58;
-    //     const amount = parseUnits("1000.0", await poolToken.decimals());
-    //     const poolInfo = await cvxBooster.poolInfo(convexPoolId);
-    //     const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
-    //     const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+    it("Should only claim rewards", async () => {
+        const curvePool = "0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89";
+        const poolToken: IERC20Metadata = frax;
+        const exitToken: IERC20Metadata = usdc;
+        const poolSize = 3;
+        const tokenIndexInCurve = 0;
+        const convexPoolId = 58;
+        const amount = parseUnits("1000.0", await poolToken.decimals());
+        const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+        const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+        const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
 
-    //     const entryData = await strategy.encodeEntryParams(
-    //         curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
-    //     );
-    //     const exitData = await strategy.encodeExitParams(
-    //         curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
-    //     );
+        const entryData = await strategy.encodeEntryParams(
+            curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId
+        );
+        const exitData = await strategy.encodeExitParams(
+            curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId
+        );
 
-    //     await poolToken.transfer(strategy.address, amount);
-    //     await strategy.invest(entryData, amount);
+        await poolToken.transfer(strategy.address, amount);
+        await strategy.invest(entryData, amount);
 
-    //     const lpBalanceBefore = await rewardPool.balanceOf(strategy.address);
-    //     const coinBalanceBefore = await exitToken.balanceOf(signers[0].address);
-    //     await strategy.exitOnlyRewards(exitData, exitToken.address, signers[0].address, true);
-    //     const lpBalanceAfter = await rewardPool.balanceOf(strategy.address);
-    //     const coinBalanceAfter = await exitToken.balanceOf(signers[0].address);
+        const lpBalanceBefore = await rewardPool.balanceOf(strategy.address);
+        const coinBalanceBefore = await exitToken.balanceOf(signers[0].address);
+        await strategy.exitOnlyRewards(exitData, exitToken.address, signers[0].address, true);
+        const lpBalanceAfter = await rewardPool.balanceOf(strategy.address);
+        const coinBalanceAfter = await exitToken.balanceOf(signers[0].address);
 
-    //     expect(lpBalanceBefore).to.not.be.equal(0);
-    //     expect(lpBalanceBefore).to.be.equal(lpBalanceAfter);
-    //     expect(coinBalanceAfter).to.be.gt(coinBalanceBefore);
-    // })
+        expect(lpBalanceBefore).to.not.be.equal(0);
+        expect(lpBalanceBefore).to.be.equal(lpBalanceAfter);
+        expect(coinBalanceAfter).to.be.gt(coinBalanceBefore);
+    })
 
     describe("Testing with Native ETH", async () => {
         it("Should execute full investment", async () => {

--- a/test/CurveFraxConvexStrategy.ts
+++ b/test/CurveFraxConvexStrategy.ts
@@ -1,0 +1,392 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import { AbiCoder, defaultAbiCoder, parseEther, parseUnits } from "ethers/lib/utils";
+import { ethers, network } from "hardhat";
+import { CurveFraxConvexStrategy, CurveFraxConvexStrategy__factory, ICvxBooster, IERC20, IERC20Metadata, IExchange, IWrappedEther } from "../typechain";
+
+describe("CurveConvexStrategy", function () {
+    let strategy: CurveFraxConvexStrategy;
+    let signers: SignerWithAddress[];
+
+    let usdc: IERC20Metadata, usdt: IERC20Metadata, frax: IERC20Metadata, crv: IERC20Metadata, cvx: IERC20Metadata, weth: IERC20Metadata;
+    let cvxBooster: ICvxBooster;
+    let exchange: IExchange;
+
+    const ZERO_ADDR = ethers.constants.AddressZero;
+
+    async function investTimeTravel() {
+        return ethers.provider.send("evm_increaseTime", []);
+    }
+
+    before(async () => {
+        signers = await ethers.getSigners();
+
+        usdc = await ethers.getContractAt("IERC20Metadata", "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+        usdt = await ethers.getContractAt("IERC20Metadata", "0xdAC17F958D2ee523a2206206994597C13D831ec7");
+        frax = await ethers.getContractAt('IERC20Metadata', '0x853d955acef822db058eb8505911ed77f175b99e');
+        crv = await ethers.getContractAt("IERC20Metadata", "0xD533a949740bb3306d119CC777fa900bA034cd52");
+        cvx = await ethers.getContractAt("IERC20Metadata", "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B");
+        weth = await ethers.getContractAt("IERC20Metadata", "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+        cvxBooster = await ethers.getContractAt("ICvxBooster", "0xF403C135812408BFbE8713b5A23a04b3D48AAE31");
+        exchange = await ethers.getContractAt("IExchange", "0x29c66CF57a03d41Cfe6d9ecB6883aa0E2AbA21Ec")
+
+        const value = parseEther("2000.0");
+
+        await exchange.exchange(
+            ZERO_ADDR, frax.address, value, 0, { value: value }
+        )
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [{
+                forking: {
+                    enabled: true,
+                    jsonRpcUrl: process.env.MAINNET_FORKING_URL as string,
+                    //you can fork from last block by commenting next line
+                    blockNumber: 15475317,
+                },
+            }, ],
+        });
+    });
+
+    beforeEach(async () => {
+        const Strategy = await ethers.getContractFactory("CurveFraxConvexStrategy") as CurveFraxConvexStrategy__factory;
+        strategy = await Strategy.deploy(ZERO_ADDR, ZERO_ADDR, true);
+        await exchange.exchange(
+            ZERO_ADDR, frax.address, parseEther("100"), 0, { value:  parseEther("100")})
+    });
+
+    it("Should check initial contract state", async () => {
+        const cvxBooster = "0xF403C135812408BFbE8713b5A23a04b3D48AAE31";
+        const exchange = "0x29c66CF57a03d41Cfe6d9ecB6883aa0E2AbA21Ec";
+        const cvxRewards = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+        const crvRewards = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+        const unwindDecimals = 2;
+        const adminRole = await strategy.DEFAULT_ADMIN_ROLE();
+
+        expect(await strategy.cvxBooster()).to.be.equal(cvxBooster);
+        expect(await strategy.exchange()).to.be.equal(exchange);
+        expect(await strategy.cvxRewards()).to.be.equal(cvxRewards);
+        expect(await strategy.crvRewards()).to.be.equal(crvRewards);
+        expect(await strategy.unwindDecimals()).to.be.equal(unwindDecimals);
+
+        expect(await strategy.hasRole(adminRole, signers[0].address)).to.be.true;
+    });
+
+    it("Should check initial contract state (testing == false)", async () => {
+        const contract1 = usdc.address;
+        const contract2 = usdt.address;
+        const adminRole = ethers.constants.HashZero;
+
+        expect(contract1).to.not.be.equal(contract2);
+
+        const Strategy = await ethers.getContractFactory("CurveFraxConvexStrategy");
+        const newStrategy = await Strategy.deploy(contract1, contract2, false);
+
+        expect(await newStrategy.hasRole(adminRole, contract1)).to.be.true;
+        expect(await newStrategy.hasRole(adminRole, contract2)).to.be.true;
+    });
+
+    it("Should not deploy contract (gnosis/voteExecutor not contract)", async () => {
+        const notContract = signers[1].address;
+        const contract = usdc.address;
+
+        const Strategy = await ethers.getContractFactory("CurveConvexStrategy");
+
+        let newStrategy = Strategy.deploy(notContract, contract, false);
+        await expect(newStrategy).to.be.revertedWith("CurveConvexStrategy: 1!contract");
+
+        newStrategy = Strategy.deploy(contract, notContract, false);
+        await expect(newStrategy).to.be.revertedWith("CurveConvexStrategy: 2!contract");
+    })
+
+    it("Should check roles", async () => {
+        const contract = usdc.address;
+        const roleError = `AccessControl: account ${signers[0].address.toLowerCase()} is missing role ${ethers.constants.HashZero}`;
+
+        const Strategy = await ethers.getContractFactory("CurveFraxConvexStrategy");
+        const newStrategy = await Strategy.deploy(contract, contract, false);
+
+        await expect(newStrategy.invest("0x", 0)).to.be.revertedWith(roleError);
+        await expect(newStrategy.exitAll("0x", 0, contract, contract, true)).to.be.revertedWith(roleError);
+        await expect(newStrategy.exitOnlyRewards("0x", contract, contract, true)).to.be.revertedWith(roleError);
+        await expect(newStrategy.multicall([], [])).to.be.revertedWith(roleError);
+    });
+
+    it("Should check correct encoders/decoders", async () => {
+        const curvePool = "0x0000000000000000000000000000000000000001";
+        const poolToken = "0x0000000000000000000000000000000000000002";
+        const poolSize = 3;
+        const tokenIndexInCurve = 4;
+        const convexPoolId = 5;
+        const lpToken = "0x0000000000000000000000000000000000000006"
+        const stakeToken = "0x0000000000000000000000000000000000000008";
+        const fraxPool = "0x0000000000000000000000000000000000000009";
+        const duration = 5
+        const kek = ethers.utils.formatBytes32String("helloworld")
+        const entry = defaultAbiCoder.encode(
+            ["address", "address ", "address", "uint8", "uint8", "uint256", "address", "address", "uint256"],
+            [curvePool, lpToken, poolToken, poolSize, tokenIndexInCurve, convexPoolId, stakeToken, fraxPool, duration]
+        )
+        const exit = defaultAbiCoder.encode(
+            ["address", "address", "address", "uint8", "uint256", "address", "bytes32"],
+            [curvePool, poolToken, lpToken, tokenIndexInCurve, convexPoolId, fraxPool, kek]
+        );
+
+        expect(await strategy.encodeEntryParams(
+            curvePool, lpToken, poolToken, poolSize, tokenIndexInCurve, convexPoolId, stakeToken, fraxPool, duration
+        )).to.be.equal(entry);
+
+        expect(await strategy.encodeExitParams(
+            curvePool, poolToken, lpToken, tokenIndexInCurve, convexPoolId, fraxPool, kek
+        )).to.be.equal(exit);
+
+        const entryStruct = await strategy.decodeEntryParams(entry);
+        const exitStruct = await strategy.decodeExitParams(exit);
+
+        expect(entryStruct[0]).to.be.equal(curvePool);
+        expect(entryStruct[1]).to.be.equal(lpToken);
+        expect(entryStruct[2]).to.be.equal(poolToken);
+        expect(entryStruct[3]).to.be.equal(poolSize);
+        expect(entryStruct[4]).to.be.equal(tokenIndexInCurve);
+        expect(entryStruct[5]).to.be.equal(convexPoolId);
+        expect(entryStruct[6]).to.be.equal(stakeToken);
+        expect(entryStruct[7]).to.be.equal(fraxPool);
+        expect(entryStruct[8]).to.be.equal(duration);
+
+
+        expect(exitStruct[0]).to.be.equal(curvePool);
+        expect(exitStruct[1]).to.be.equal(poolToken);
+        expect(exitStruct[2]).to.be.equal(lpToken);
+        expect(exitStruct[3]).to.be.equal(tokenIndexInCurve);
+        expect(exitStruct[4]).to.be.equal(convexPoolId);
+        expect(exitStruct[5]).to.be.equal(fraxPool);
+        expect(exitStruct[6]).to.be.equal(kek);
+    });
+
+    it("Should revert decoders if data length is wrong", async () => {
+        const data = "0x420690";
+
+        const entry = strategy.decodeEntryParams(data);
+        const exit = strategy.decodeExitParams(data);
+
+        await expect(entry).to.be.revertedWith("CurveConvexStrategy: length en");
+        await expect(exit).to.be.revertedWith("CurveConvexStrategy: length ex");
+    });
+
+    // it("Should execute full investment", async () => {
+    //     const curvePool = "0xDcEF968d416a41Cdac0ED8702fAC8128A64241A2";
+    //     const poolToken: IERC20Metadata = frax;
+    //     const poolSize = 2;
+    //     const tokenIndexInCurve = 0;
+    //     const convexPoolId = 100;
+    //     const amount = parseUnits("10.0", await poolToken.decimals());
+
+    //     const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+
+    //     const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+
+    //     const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+
+    //     const stakeToken = await ethers.getContractAt("IERC20", "0x8a53ee42FB458D4897e15cc7dEa3F75D0F1c3475")
+    //     const fraxPool = "0x963f487796d54d2f27bA6F3Fbe91154cA103b199"
+    //     const duration = 694000
+    //     const entryData = await strategy.encodeEntryParams(
+    //         curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId, stakeToken.address, fraxPool, duration
+    //     )
+    //     expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     const investBefore = await stakeToken.balanceOf(strategy.address);
+
+    //     await poolToken.transfer(strategy.address, amount);
+
+    //     await strategy.invest(entryData, amount);
+
+    //     const investAfter = await stakeToken.balanceOf(strategy.address);
+
+    //     expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+    //     // We must have 0 stake token left because they must be locked up.
+    //     expect(investAfter).to.be.equal(investBefore);
+    // });
+
+    it("Should exit only rewards and swap to Frax", async () => {
+
+
+        const strategy2 = await ethers.getContractFactory("CurveFraxConvexStrategy") as CurveFraxConvexStrategy__factory;
+        strategy = await strategy2.connect(signers[2]).deploy(ZERO_ADDR, ZERO_ADDR, true);
+        await exchange.connect(signers[2]).exchange(
+            ZERO_ADDR, frax.address, parseEther("100"), 0, { value:  parseEther("100")})
+
+
+        const curvePool = "0xDcEF968d416a41Cdac0ED8702fAC8128A64241A2";
+        const poolToken: IERC20Metadata = frax;
+        const poolSize = 2;
+        const tokenIndexInCurve = 0;
+        const convexPoolId = 100;
+        const amount = parseUnits("10.0", await poolToken.decimals());
+
+        const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+
+        const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+
+        const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+
+        const stakeToken = "0x8a53ee42FB458D4897e15cc7dEa3F75D0F1c3475"
+        const fraxPool = "0x963f487796d54d2f27bA6F3Fbe91154cA103b199"
+        const duration = 800000
+        const entryData = await strategy.encodeEntryParams(
+            curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId, stakeToken, fraxPool, duration
+        )
+
+        await poolToken.connect(signers[2]).transfer(strategy.address, amount);
+
+        const tx = await strategy.connect(signers[2]).invest(entryData, amount);
+        const receipt = await tx.wait()
+
+        let abi = [ "event Locked(bytes32 data)" ];
+        let iface = new ethers.utils.Interface(abi);
+        let log = iface.parseLog(receipt.logs[receipt.logs.length-1]); 
+
+        const kek_id =log.args[0]
+
+        const exitData = await strategy.encodeExitParams(curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId, fraxPool, kek_id)
+        await ethers.provider.send("evm_increaseTime", [1000000])
+
+        
+        const balanceBefore = await frax.balanceOf(signers[0].address);
+        await strategy.connect(signers[2]).exitOnlyRewards(exitData, frax.address, signers[0].address, true);
+        const balanceAfter = await frax.balanceOf(signers[0].address);
+
+        expect(balanceAfter).to.be.gt(balanceBefore);
+        expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await frax.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await rewardPool.balanceOf(strategy.address)).to.be.equal(0);
+
+        expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await crv.balanceOf(signers[0].address)).to.be.equal(0);
+        expect(await cvx.balanceOf(signers[0].address)).to.be.equal(0);
+    });
+    it("Should exit only rewards and don't swap", async () => {
+        const curvePool = "0xDcEF968d416a41Cdac0ED8702fAC8128A64241A2";
+        const poolToken: IERC20Metadata = frax;
+        const poolSize = 2;
+        const tokenIndexInCurve = 0;
+        const convexPoolId = 100;
+        const amount = parseUnits("10.0", await poolToken.decimals());
+
+        const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+
+        const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+
+        const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+
+        const stakeToken = "0x8a53ee42FB458D4897e15cc7dEa3F75D0F1c3475"
+        const fraxPool = "0x963f487796d54d2f27bA6F3Fbe91154cA103b199"
+        const duration = 694000
+        const entryData = await strategy.encodeEntryParams(
+            curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId, stakeToken, fraxPool, duration
+        )
+
+        await poolToken.transfer(strategy.address, amount);
+
+        const tx = await strategy.invest(entryData, amount);
+        const receipt = await tx.wait()
+
+        let abi = [ "event Locked(bytes32 data)" ];
+        let iface = new ethers.utils.Interface(abi);
+        let log = iface.parseLog(receipt.logs[receipt.logs.length-1]); 
+
+        const kek_id =log.args[0]
+
+        const exitData = await strategy.encodeExitParams(curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId, fraxPool, kek_id)
+        await ethers.provider.send("evm_increaseTime", [900000])
+
+        
+        const balanceBefore = await frax.balanceOf(signers[0].address);
+        await strategy.exitOnlyRewards(exitData, frax.address, signers[0].address, false);
+        const balanceAfter = await frax.balanceOf(signers[0].address);
+
+        expect(balanceAfter).to.be.equal(balanceBefore);
+      
+        expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await crv.balanceOf(signers[0].address)).to.be.gt(0);
+        expect(await cvx.balanceOf(signers[0].address)).to.be.gt(0);
+        const fraxShare = await ethers.getContractAt("IERC20", "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0")
+        console.log(await fraxShare.balanceOf(signers[0].address))
+        expect(await fraxShare.balanceOf(signers[0].address)).to.be.gt(0);
+    });
+
+    it("Should unwind investment", async () => {
+        const curvePool = "0xDcEF968d416a41Cdac0ED8702fAC8128A64241A2";
+        const poolToken: IERC20Metadata = frax;
+        const poolSize = 2;
+        const tokenIndexInCurve = 0;
+        const convexPoolId = 100;
+        const amount = parseUnits("10000.0", await poolToken.decimals());
+
+        const poolInfo = await cvxBooster.poolInfo(convexPoolId);
+
+        const lpToken = await ethers.getContractAt("IERC20Metadata", poolInfo.lptoken)
+
+        const rewardPool = await ethers.getContractAt("ICvxBaseRewardPool", poolInfo.crvRewards)
+
+        const stakeToken = "0x8a53ee42FB458D4897e15cc7dEa3F75D0F1c3475"
+        const fraxPool = "0x963f487796d54d2f27bA6F3Fbe91154cA103b199"
+        const duration = 694000 *2
+        const entryData = await strategy.encodeEntryParams(
+            curvePool, lpToken.address, poolToken.address, poolSize, tokenIndexInCurve, convexPoolId, stakeToken, fraxPool, duration
+        )
+
+        await poolToken.transfer(strategy.address, amount);
+
+        const tx = await strategy.invest(entryData, amount);
+        const receipt = await tx.wait()
+
+        let abi = [ "event Locked(bytes32 data)" ];
+        let iface = new ethers.utils.Interface(abi);
+        let log = iface.parseLog(receipt.logs[receipt.logs.length-1]); 
+
+        const kek_id =log.args[0]
+
+        const exitData = await strategy.encodeExitParams(curvePool, poolToken.address, lpToken.address, tokenIndexInCurve, convexPoolId, fraxPool, kek_id)
+        await ethers.provider.send("evm_increaseTime", [900000*2])
+
+        
+        const balanceBefore = await frax.balanceOf(signers[0].address);
+        await strategy.exitAll(exitData, 10000, frax.address, signers[0].address, true);
+        const balanceAfter = await frax.balanceOf(signers[0].address);
+
+        expect(balanceAfter).to.be.gt(balanceBefore);
+        expect(await poolToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await frax.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await lpToken.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await rewardPool.balanceOf(strategy.address)).to.be.equal(0);
+
+        expect(await crv.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await cvx.balanceOf(strategy.address)).to.be.equal(0);
+        expect(await crv.balanceOf(signers[0].address)).to.be.equal(0);
+        expect(await cvx.balanceOf(signers[0].address)).to.be.equal(0);
+    })
+
+    it("Should execute mulicall", async () => {
+        const token = frax;
+        const amount = parseUnits("200.0", await token.decimals());
+        const calldata1 = token.interface.encodeFunctionData("transfer", [signers[0].address, parseUnits("150.0", await token.decimals())]);
+        const calldata2 = token.interface.encodeFunctionData("transfer", [signers[0].address, parseUnits("50.0", await token.decimals())]);
+
+        const balanceBefore = await token.balanceOf(strategy.address);
+        await token.transfer(strategy.address, amount);
+        await strategy.multicall([token.address, token.address], [calldata1, calldata2]);
+        const balanceAfter = await token.balanceOf(strategy.address);
+
+        expect(balanceAfter).to.be.equal(balanceBefore);
+    })
+});
+// Cvx rewards 12484281607000998
+// Crv rewards 219022484333350995
+
+// 7512367276821111,
+// 24170848862983073,
+// 1377738385190035


### PR DESCRIPTION
Accidentally used my forked repo but should be ok.

1. CurveConvexStrategy compatible with native eth pools with fixes in withdraw

2. CurveFraxConvexStrategy compatible with Frax Finance.  (This one is still testing live).

3. CurveConvexStrategy that works with the newest vote executor with liquidity direction. 

Tests for CurveFraxConvexStrategy seems to have an issue with rewards accumulation in the fork. Therefore we are testing this before putting it to produciton.